### PR TITLE
JA4SSH: Look for bare ACK flags when counting ACK packets

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2023-12-22
+
+### Fixed
+
+- JA4SSH: When counting ACK packets, look for bare ACK flags only, skipping SYN-ACK,
+  PSH-ACK, FIN-ACK, etc. (#36)
+
 ## [0.16.0] - 2023-12-12
 
 ### Changed
@@ -41,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Rust sources of `ja4` and `ja4x` CLI tools.
 
-[unreleased]: https://github.com/FoxIO-LLC/ja4/compare/v0.16.0...HEAD
+[unreleased]: https://github.com/FoxIO-LLC/ja4/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/FoxIO-LLC/ja4/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/FoxIO-LLC/ja4/compare/v0.15.2...v0.16.0
 [0.15.2]: https://github.com/FoxIO-LLC/ja4/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/FoxIO-LLC/ja4/compare/v0.15.0...v0.15.1

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -531,7 +531,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "ja4"
-version = "0.15.2"
+version = "0.16.1"
 dependencies = [
  "clap",
  "color-eyre",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "ja4x"
-version = "0.15.2"
+version = "0.16.1"
 dependencies = [
  "clap",
  "color-eyre",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ja4", "ja4x"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.2"
+version = "0.16.1"
 license = "LicenseRef-FoxIO-Proprietary"
 repository = "https://github.com/FoxIO-LLC/ja4"
 

--- a/rust/ja4/src/snapshots/ja4__insta@ssh-scp-1050.pcap.snap
+++ b/rust/ja4/src/snapshots/ja4__insta@ssh-scp-1050.pcap.snap
@@ -11,7 +11,7 @@ expression: output
   ja4l_c: 179_128
   ja4l_s: 38_64
   ja4ssh:
-  - c112s80_c52s107_c35s5
+  - c112s80_c52s107_c35s4
   - c0s1460_c0s174_c26s0
   - c112s1460_c13s150_c37s0
   - c0s1460_c0s178_c22s0

--- a/rust/ja4/src/snapshots/ja4__insta@ssh2.pcapng.snap
+++ b/rust/ja4/src/snapshots/ja4__insta@ssh2.pcapng.snap
@@ -172,7 +172,7 @@ expression: output
   ja4l_c: 77_128
   ja4l_s: 12897_50
   ja4ssh:
-  - c36s36_c55s87_c51s6
+  - c36s36_c55s87_c51s5
   - c36s36_c49s90_c59s2
   - c36s36_c14s23_c15s0
   ssh_extras:

--- a/rust/ja4/src/ssh.rs
+++ b/rust/ja4/src/ssh.rs
@@ -207,6 +207,8 @@ struct PacketCounts {
 
 impl PacketCounts {
     fn update(&mut self, pkt: &Packet, sender: Sender) -> Result<()> {
+        const BARE_ACK_FLAG: &str = "0x0010";
+
         // SAFETY: We would not reach this point if the packet didn't have a "tcp" layer;
         // see `Streams::update` and `StreamId2::new`. It's safe to unwrap.
         let tcp = pkt.find_proto("tcp").unwrap();
@@ -223,7 +225,7 @@ impl PacketCounts {
                     self.nr_ssh_server_packets += 1;
                 }
             }
-        } else if ["1", "True"].contains(&tcp.first("tcp.flags.ack")?) {
+        } else if tcp.first("tcp.flags")? == BARE_ACK_FLAG {
             match sender {
                 Sender::Client => self.nr_tcp_client_acks += 1,
                 Sender::Server => self.nr_tcp_server_acks += 1,


### PR DESCRIPTION
Related issue: #36