### PR TITLE
Added check if SSL connection ids exist to prevent exceptions in zeek

### DIFF
--- a/zeek/ja4/main.zeek
+++ b/zeek/ja4/main.zeek
@@ -202,6 +202,8 @@ function do_ja4(c: connection) {
 #  Conduct operations on ClientHello record in c$fp to create JA4 record as c$fp$ja4
 
 hook SSL::log_policy(rec: SSL::Info, id: Log::ID, filter: Log::Filter) {
-  local c = lookup_connection(rec$id);
-  do_ja4(c);
+  if(connection_exists(rec$id)){
+    local c = lookup_connection(rec$id);
+    do_ja4(c);
+  }
 }

--- a/zeek/ja4s/main.zeek
+++ b/zeek/ja4s/main.zeek
@@ -159,6 +159,8 @@ function do_ja4s(c: connection) {
 }
 
 hook SSL::log_policy(rec: SSL::Info, id: Log::ID, filter: Log::Filter) {
-  local c = lookup_connection(rec$id);
-  do_ja4s(c);
+  if(connection_exists(rec$id)){
+    local c = lookup_connection(rec$id);
+    do_ja4s(c);
+  }
 }


### PR DESCRIPTION
When JA4 and JA4s scripts respectively were run they would sometimes create exceptions like this:

JA4s:
> 1709820249.822994 error in /opt/zeek/share/zeek/site/./ja4/./ja4s/./main.zeek, line 163: connection ID not a known connection (lookup_connection(FINGERPRINT::JA4S::rec$id) and [orig_h=x.x.x.x, orig_p=56810/tcp, resp_h=x.x.x.x, resp_p=443/tcp])

JA4:
> error in /opt/zeek/share/zeek/site/./ja4/./ja4/./main.zeek, line 205: connection ID not a known connection (lookup_connection(FINGERPRINT::JA4::rec$id) and [orig_h=x.x.x.x, orig_p=x/tcp, resp_h=x.x.x.x, resp_p=x/tcp])

This patch first checks if the connection ID exists and then does the lookup, thus avoiding the exception output.