### PR TITLE
Add support for Zeek 5

### DIFF
--- a/zeek/ja4/main.zeek
+++ b/zeek/ja4/main.zeek
@@ -38,7 +38,7 @@ export {
 }
 
 redef record FINGERPRINT::Info += {
-  ja4: FINGERPRINT::JA4::Info &default=[];
+  ja4: FINGERPRINT::JA4::Info &default=Info();
 };
 
 redef record SSL::Info += {
@@ -138,7 +138,8 @@ function do_ja4(c: connection) {
   local ja4_b: vector of count = c$fp$client_hello$cipher_suites;
 
   local extensions: vector of count = vector();
-  for (idx, code in c$fp$client_hello$extension_codes) {
+  for (idx in c$fp$client_hello$extension_codes) {
+    local code = c$fp$client_hello$extension_codes[idx];
     if (code == SSL::SSL_EXTENSION_SERVER_NAME || code == SSL::SSL_EXTENSION_APPLICATION_LAYER_PROTOCOL_NEGOTIATION) {
       next;
     }

--- a/zeek/ja4h/main.zeek
+++ b/zeek/ja4h/main.zeek
@@ -29,7 +29,7 @@ export {
 }
 
 redef record FINGERPRINT::Info += {
-  ja4h: FINGERPRINT::JA4H::Info &default=[];
+  ja4h: FINGERPRINT::JA4H::Info &default=Info();
 };
 
 redef record HTTP::Info += {
@@ -61,7 +61,7 @@ export {
 }
 
 redef record FINGERPRINT::Info += {
-  http_client: HttpClient &default=[];
+  http_client: HttpClient &default=HttpClient();
 };
 
 
@@ -75,13 +75,14 @@ event zeek_init() &priority=5 {
 
 event http_header (c: connection, is_orig: bool, original_name: string, name: string, value: string)
 {
-    if (!c?$fp) { c$fp = []; }
+    if (!c?$fp) { c$fp = FINGERPRINT::Info(); }
     if (is_orig) {
         c$fp$http_client$header_names_o += original_name;
         if (name == "COOKIE") {
             c$fp$http_client$cookie = value;
-            for (_, cookie in split_string(value, /;/)) {
-                cookie = strip(cookie);
+            local cookies = split_string(value, /;/);
+            for (idx in cookies) {
+                local cookie = strip(cookies[idx]);
                 c$fp$http_client$cookie_values += cookie;
                 c$fp$http_client$cookie_names += split_string1(cookie, /=/)[0];
             }
@@ -122,7 +123,7 @@ global HTTP_METHOD_MAP: table[string] of string = {
 
 event http_request(c: connection, method: string, original_URI: string, unescaped_URI: string, version: string)
 {
-    if (!c?$fp) { c$fp = []; }
+    if (!c?$fp) { c$fp = FINGERPRINT::Info(); }
 
     # clear the last request if there was one
     c$fp$http_client = [];

--- a/zeek/ja4l/main.zeek
+++ b/zeek/ja4l/main.zeek
@@ -48,7 +48,7 @@ export {
 }
 
 redef record FINGERPRINT::Info += {
-  ja4l: FINGERPRINT::JA4L::Info &default=[];
+  ja4l: FINGERPRINT::JA4L::Info &default=Info();
 };
 
 redef record Conn::Info += {
@@ -70,7 +70,7 @@ function get_current_packet_timestamp(): double {
 
 event new_connection(c: connection) {
     
-    if(!c?$fp) { c$fp = []; }
+    if(!c?$fp) { c$fp = FINGERPRINT::Info(); }
     
     local rp = get_current_packet_header();
     if (rp?$tcp && rp$tcp$flags != TH_SYN) {
@@ -158,7 +158,7 @@ event ssl_server_hello(c: connection, version: count, record_version: count, pos
 
 event QUIC::initial_packet(c: connection, is_orig: bool, version: count, dcid: string, scid: string) {
 
-    if(!c?$fp) { c$fp = []; }
+    if(!c?$fp) { c$fp = FINGERPRINT::Info(); }
 
     local rp = get_current_packet_header();
     if (is_orig) {

--- a/zeek/ja4ssh/main.zeek
+++ b/zeek/ja4ssh/main.zeek
@@ -33,7 +33,7 @@ export {
 }
 
 redef record FINGERPRINT::Info += {
-  ja4ssh: FINGERPRINT::JA4SSH::Info &default=[];
+  ja4ssh: FINGERPRINT::JA4SSH::Info &default=Info();
 };
 
 # Create the log stream and file
@@ -46,7 +46,8 @@ event zeek_init() &priority=5 {
 function get_mode(vec: vector of count): count {
   local freqs: table[count] of count = table();
    
-  for (_,v in vec) {
+  for (idx in vec) {
+    local v = vec[idx];
     if(v in freqs) {
       ++freqs[v];
     } else {
@@ -55,10 +56,11 @@ function get_mode(vec: vector of count): count {
   }
   local max = 0;
   local mode = 0;
-  for (i,v in freqs) {
-    if (v > max) {
-      max = v;
-      mode = i;
+  for (idx in freqs) {
+    local freq = freqs[idx];
+    if (freq > max) {
+      max = freq;
+      mode = idx;
     }
   }
 

--- a/zeek/ja4t/main.zeek
+++ b/zeek/ja4t/main.zeek
@@ -21,10 +21,10 @@ export {
   # The fingerprint context 
   type Info: record {
     syn_window_size: count &default=0;
-    syn_opts: TCP_Options &default=[];    
+    syn_opts: TCP_Options &default=TCP_Options();    
 
     synack_window_size: count &default=0;
-    synack_opts: TCP_Options &default=[];
+    synack_opts: TCP_Options &default=TCP_Options();
     synack_delays: vector of count &default=vector();
     synack_done: bool &default=F;
     last_ts: double &default=0;
@@ -35,7 +35,7 @@ export {
 }
 
 redef record FINGERPRINT::Info += {
-  ja4t: FINGERPRINT::JA4T::Info &default=[];
+  ja4t: FINGERPRINT::JA4T::Info &default= Info();
 };
 
 redef record Conn::Info += {
@@ -124,7 +124,7 @@ event new_connection(c: connection) {
         return;  
     }
 
-    if(!c?$fp) { c$fp = []; }
+    if(!c?$fp) { c$fp = FINGERPRINT::Info(); }
     
     c$fp$ja4t$syn_window_size = rph$tcp$win;
     c$fp$ja4t$syn_opts = get_tcp_options();

--- a/zeek/utils/common.zeek
+++ b/zeek/utils/common.zeek
@@ -21,7 +21,8 @@ export {
 function vector_of_count_to_str(input: vector of count, format_str: string &default="%04x", 
     dlimit: string &default=","): string {
     local output = "";
-    for (idx, val in input) {
+    for (idx in input) {
+        local val = input[idx];
         output += fmt(format_str, val);
         if (idx < |input|-1) {
         output += dlimit;
@@ -34,7 +35,8 @@ function vector_of_count_to_str(input: vector of count, format_str: string &defa
 function vector_of_str_to_str(input: vector of string, format_str: string &default="%s", 
     dlimit: string &default=","): string {
     local output = "";
-    for (idx, val in input) {
+    for (idx in input) {
+        local val = input[idx];
         output += fmt(format_str, val);
         if (idx < |input|-1) {
         output += dlimit;
@@ -47,7 +49,8 @@ function vector_of_str_to_str(input: vector of string, format_str: string &defau
 function order_vector_of_count(input: vector of count): vector of count {
     local ordering: vector of count = order(input);
     local outvec: vector of count = vector();
-    for (idx, val in ordering) {
+    for (idx in ordering) {
+        local val = ordering[idx];
         outvec += input[val];
     }
     return outvec;


### PR DESCRIPTION
The initial version of JA4+ for Zeek was using syntactic sugar that was added in Zeek 6 and would fail to compile then segfault on Zeek 5.  

Thanks to Justin Azoff for identifying the cause of the segfault (using [] instead of RecordType() as a initializer).