### PR TITLE
fixed crash when ja4x has only one extension

### DIFF
--- a/python/ja4x.py
+++ b/python/ja4x.py
@@ -78,10 +78,12 @@ def to_ja4x(x, debug_stream=-1):
     for idx, i in enumerate(x['extension_lengths']):
         i = int(i)
         header_len = '{:02d}'.format(i)
-        exts = x['cert_extensions'][:i]
-        del x['cert_extensions'][:i]
+        exts = x['cert_extensions'][:i] if isinstance(x['cert_extensions'], list) else [ x['cert_extensions']  ]
+        if isinstance(x['cert_extensions'], list):
+            del x['cert_extensions'][:i]
         hex_strings = [ oid_to_hex(ext) for ext in exts ]
-        # compute the ha4x for each cert
+
+        # compute the ja4x hash for each cert
         x[f'JA4X.{idx+1}'] = f'{x["issuer_hashes"][idx]}_{x["subject_hashes"][idx]}_' + sha256(",".join(hex_strings).encode('utf8')).hexdigest()[:12]
         cache_update(x, f'JA4X.{idx+1}', x[f'JA4X.{idx+1}'], debug_stream)
     return x


### PR DESCRIPTION
JA4X displays hases correctly now when there is only one extension

```
>python3 python/ja4.py --ja4x /mnt/c/Users/tnoel/Downloads/one-extension/one-extension.pcap --json -r
{
    "stream": 0,
    "src": "192.254.79.71",
    "dst": "10.2.2.101",
    "srcport": "443",
    "dstport": "49802",
    "JA4X.1": "2166164053c1_2166164053c1_30d204a01551"
}
```