### PR TITLE
Clarify alpn edge case handling

### DIFF
--- a/technical_details/JA4.md
+++ b/technical_details/JA4.md
@@ -62,13 +62,13 @@ Same as counting ciphers. Ignore GREASE. Include SNI and ALPN.
 The first and last characters of the ALPN (Application-Layer Protocol Negotiation) first value.  
 List of possible ALPN Values (scroll down): https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml
 
-
-
 In the above example, the first ALPN value is h2 so the first and last characters to use in the fingerprint are “h2”. IF the first ALPN listed was http/1.1 then the first and last characters to use in the fingerprint would be “h1”.
 
 In Wireshark this field is located under tls.handshake.extensions_alpn_str
 
-If there are no ALPN values or no ALPN extension then we print “00” as the value in the fingerprint. If the ALPN value is only a single character, the last character is "0". Non-ascii characters (characters with codes >127) should be represented as "9".
+If there are no ALPN values or no ALPN extension then we print “00” as the value in the fingerprint. If the ALPN value is only a single character, then the last character is "0".
+
+If the first character of the ALPN is non-alphanumeric, then the first character of its hex representation should be used instead. If the last character of the ALPN is non-alphanumeric, then the last character of its hex representation should be used instead. So if the ALPN is [ 0xab, 0xcd, 0xef ], then we print "af" in the fingerprint.
 
 ### Cipher hash:
 A 12 character truncated sha256 hash of the list of ciphers sorted in hex order, first 12 characters. The list is created using the 4 character hex values of the ciphers, lower case, comma delimited, ignoring GREASE.  

--- a/technical_details/JA4.md
+++ b/technical_details/JA4.md
@@ -68,7 +68,7 @@ In the above example, the first ALPN value is h2 so the first and last character
 
 In Wireshark this field is located under tls.handshake.extensions_alpn_str
 
-If there are no ALPN values or no ALPN extension then we print “00” as the value in the fingerprint.
+If there are no ALPN values or no ALPN extension then we print “00” as the value in the fingerprint. If the ALPN value is only a single character, the last character is "0". Non-ascii characters (characters with codes >127) should be represented as "9".
 
 ### Cipher hash:
 A 12 character truncated sha256 hash of the list of ciphers sorted in hex order, first 12 characters. The list is created using the 4 character hex values of the ciphers, lower case, comma delimited, ignoring GREASE.  


### PR DESCRIPTION
The technical details are unclear on alpn edge case handling. This was discussed previously in https://github.com/FoxIO-LLC/ja4/issues/16, but it doesn't seem like there was a consensus because the different implementations are all doing different things. As a follow-up to this change, the implementations should probably be changed to be consistent.

This PR codifies what the rust implementation does:
- missing characters: https://github.com/FoxIO-LLC/ja4/blob/259739593049478dc68c84a436eca75b9f404e6e/rust/ja4/src/tls.rs#L333-L334
- non-ascii characters: https://github.com/FoxIO-LLC/ja4/blob/259739593049478dc68c84a436eca75b9f404e6e/rust/ja4/src/tls.rs#L621-L625

It looks like the python implementation is similar but a little different, and assumes that if the first character is non-ascii then so is the second character: https://github.com/FoxIO-LLC/ja4/blob/259739593049478dc68c84a436eca75b9f404e6e/python/ja4.py#L195-L196 That seems a little strange to me, and might just be a bug.

The Wireshark implementation is completely different and takes the first and last nibble. If that's preferred to the Rust version, I can instead update the docs to reflect that.

Frankly I have no idea what [the zeek implementation](https://github.com/FoxIO-LLC/ja4/blob/main/zeek/ja4/main.zeek#L86-L89) is doing, but it's not obviously handling either edge case?