### PR TITLE
Zeek: fix ja4_c with no signature algorithms

### DIFF
--- a/zeek/ja4/main.zeek
+++ b/zeek/ja4/main.zeek
@@ -148,9 +148,11 @@ function do_ja4(c: connection) {
 
   local ja4_c: string = FINGERPRINT::vector_of_count_to_str(
     FINGERPRINT::order_vector_of_count(extensions));
-  ja4_c += FINGERPRINT::delimiter;
-  ja4_c += FINGERPRINT::vector_of_count_to_str(c$fp$client_hello$signature_algos);
-  
+  if (|c$fp$client_hello$signature_algos| > 0) {
+    ja4_c += FINGERPRINT::delimiter;
+    ja4_c += FINGERPRINT::vector_of_count_to_str(c$fp$client_hello$signature_algos);
+  }
+
   # ja4, ja4, ja4, ja4, ja4, ja4. say it some more. ja4, ja4, ja4.
   c$fp$ja4$ja4 = ja4_a;
   c$fp$ja4$ja4 += FINGERPRINT::delimiter;
@@ -168,8 +170,10 @@ function do_ja4(c: connection) {
 
   # original extensions ordering, including APPLN and SNI
   ja4_c = FINGERPRINT::vector_of_count_to_str(c$fp$client_hello$extension_codes);
-  ja4_c += FINGERPRINT::delimiter;
-  ja4_c += FINGERPRINT::vector_of_count_to_str(c$fp$client_hello$signature_algos);
+  if (|c$fp$client_hello$signature_algos| > 0) {
+    ja4_c += FINGERPRINT::delimiter;
+    ja4_c += FINGERPRINT::vector_of_count_to_str(c$fp$client_hello$signature_algos);
+  }
 
   # ja4_o
   c$fp$ja4$o = ja4_a;


### PR DESCRIPTION
As explained by @lrstewart in #146, the [technical details](https://github.com/FoxIO-LLC/ja4/blob/main/technical_details/JA4.md#extension-hash) mention that:
> If there are no signature algorithms in the hello packet, then the string ends without an underscore and is hashed.

The current Zeek reference implementation is hence incorrect and can be fixed by this patch.