### PR TITLE
Fix SSL version fields: SSL 2.0 is 0x0002, SSL 1.0 never existed

### DIFF
--- a/python/common.py
+++ b/python/common.py
@@ -13,8 +13,7 @@ quic_cache = {}
 http_cache = {}
 ssh_cache = {}
 
-TLS_MAPPER = {'256': "s1",
-              '512': "s2",
+TLS_MAPPER = {'0x0002': "s2",
               '0x0300': "s3",
               '0x0301': "10",
               '0x0302': "11",

--- a/rust/ja4/src/tls.rs
+++ b/rust/ja4/src/tls.rs
@@ -506,8 +506,6 @@ enum TlsVersion {
     Ssl3_0,
     /// SSL 2.0
     Ssl2_0,
-    /// SSL 1.0
-    Ssl1_0,
     Unknown(String),
 }
 
@@ -519,8 +517,7 @@ impl From<&str> for TlsVersion {
             "0x0302" => TlsVersion::Tls1_1,
             "0x0301" => TlsVersion::Tls1_0,
             "0x0300" => TlsVersion::Ssl3_0,
-            "0x0200" => TlsVersion::Ssl2_0,
-            "0x0100" => TlsVersion::Ssl1_0,
+            "0x0002" => TlsVersion::Ssl2_0,
             _ => TlsVersion::Unknown(s.to_owned()),
         }
     }
@@ -535,7 +532,6 @@ impl fmt::Display for TlsVersion {
             TlsVersion::Tls1_0 => "10",
             TlsVersion::Ssl3_0 => "s3",
             TlsVersion::Ssl2_0 => "s2",
-            TlsVersion::Ssl1_0 => "s1",
             TlsVersion::Unknown(_) => "00",
         };
         write!(f, "{s}")

--- a/technical_details/JA4.md
+++ b/technical_details/JA4.md
@@ -41,8 +41,7 @@ The TLS version is shown in 3 different places. If extension 0x002b exists (supp
 0x0302 = TLS 1.1 = “11”  
 0x0301 = TLS 1.0 = “10”  
 0x0300 = SSL 3.0 = “s3”  
-0x0200 = SSL 2.0 = “s2”  
-0x0100 = SSL 1.0 = “s1”  
+0x0002 = SSL 2.0 = “s2”  
 0xfeff = DTLS 1.0 = "d1"  
 0xfefd = DTLS 1.2 = "d2"  
 0xfefc = DTLS 1.3 = "d3"  

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -76,8 +76,7 @@ static int dissect_ja4(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void
 static dissector_handle_t ja4_handle;
 
 const value_string ssl_versions[] = {
-    	{ 0x0100,   "s1" },
-    	{ 0x0200,   "s2" },
+    	{ 0x0002,   "s2" },
     	{ 0x0300,   "s3" },
     	{ 0x0301,   "10" },
     	{ 0x0302,   "11" },

--- a/zeek/utils/ssl-consts.zeek
+++ b/zeek/utils/ssl-consts.zeek
@@ -2,8 +2,7 @@ module FINGERPRINT;
 
 export {
   global TLS_VERSION_MAPPER: table[count] of string = {
-    [256] = "s1",
-    [512] = "s2",
+    [0x0002] = "s2",
     [0x0300] = "s3",
     [0x0301] = "10",
     [0x0302] = "11",


### PR DESCRIPTION
Fix version for SSL 2.0 and remove version for SSL 1.0.

SSL 2.0 [1][2] uses a version field of 0x0002, not 0x0100.  SSL 1 never existed outside of Netscape, as the original design was iterated upon to become SSL 2 before the first public version of SSL.  I don't think it's public knowledge what the version field for SSL 1.0 looked like, or if it even was two bytes large or at the same offset on the wire.

Version field 0x0100, that JA4 is currently misattributing to SSL 1.0, was used by an early pre-RFC4347 implementation of DTLS in OpenSSL before 0.9.8f [2], when OpenSSL switched to the version field specified by RFC4347.  Arguable if it makes sense to support this early form of experimental DTLS, I chose not to include it in this PR.

This fix may or may not be related to the TODO comment in the zeek code that mentions a bug where zeek returns invalid versions; I could not find the mentioned pcap in the repo so did not investigate further.

[1] https://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html
[2] https://datatracker.ietf.org/doc/html/draft-hickman-netscape-ssl-00
[3] https://github.com/openssl/openssl/compare/OpenSSL_0_9_8e...OpenSSL_0_9_8f