### PR TITLE
Documentation: Add alternative Wireshark implementation suggestions

### DIFF
--- a/wireshark/README.md
+++ b/wireshark/README.md
@@ -40,7 +40,7 @@ Add JA4+ to your columns for easy identification and sorting. Go to ```Preferenc
 
 Alternatively, they can be added to the preferences by modifiying the user's "preferences" file. To do so, find the section labeled  "User Interface: Columns" and add the following items:
 ```
-  "JA4T", "%Cus:ja4.ja4t:0:R",
+	"JA4T", "%Cus:ja4.ja4t:0:R",
 	"JA4TS", "%Cus:ja4.ja4ts:0:R",
 	"JA4", "%Cus:tls.handshake.ja4:0:R",
 	"JA4S", "%Cus:ja4.ja4s:0:R",

--- a/wireshark/README.md
+++ b/wireshark/README.md
@@ -57,7 +57,7 @@ The preference file is located in the following locations:
 #### Mac
 ~/.config/wireshark/preferences
 #### Linux
-/home/<username>/.wireshark/preferences
+~/.config/wireshark/preferences
 
 ## Licensing
 See [Licensing](https://github.com/FoxIO-LLC/ja4/tree/main#licensing) under repo root.

--- a/wireshark/README.md
+++ b/wireshark/README.md
@@ -38,5 +38,25 @@ Add JA4+ to your columns for easy identification and sorting. Go to ```Preferenc
 
 ![Config](https://github.com/FoxIO-LLC/ja4/blob/main/wireshark/column-config.png)
 
+Alternatively, they can be added to the preferences by modifiying the user's "preferences" file. To do so, find the section labeled  "User Interface: Columns" and add the following items:
+```
+  "JA4T", "%Cus:ja4.ja4t:0:R",
+	"JA4TS", "%Cus:ja4.ja4ts:0:R",
+	"JA4", "%Cus:tls.handshake.ja4:0:R",
+	"JA4S", "%Cus:ja4.ja4s:0:R",
+	"JA4H", "%Cus:ja4.ja4h:0:R",
+	"JA4L", "%Cus:ja4.ja4l:0:R",
+	"JA4LS", "%Cus:ja4.ja4ls:0:R",
+	"JA4X", "%Cus:ja4.ja4x:0:R",
+	"JA4SSH", "%Cus:ja4.ja4ssh:0:R"
+```
+The preference file is located in the following locations:
+#### Windows
+%APPDATA%\Wireshark\preferences
+#### Mac
+~/.config/wireshark/preferences
+#### Linux
+/home/<username>/.wireshark/preferences
+
 ## Licensing
 See [Licensing](https://github.com/FoxIO-LLC/ja4/tree/main#licensing) under repo root.

--- a/wireshark/README.md
+++ b/wireshark/README.md
@@ -38,7 +38,7 @@ Add JA4+ to your columns for easy identification and sorting. Go to ```Preferenc
 
 ![Config](https://github.com/FoxIO-LLC/ja4/blob/main/wireshark/column-config.png)
 
-Alternatively, they can be added to the preferences by modifiying the user's "preferences" file. To do so, find the section labeled  "User Interface: Columns" and add the following items:
+Alternatively, they can be added to the preferences by modifiying the user's "preferences" file using a text editor. In the text editor, find the section labeled  "User Interface: Columns" and add the following items:
 ```
 	"JA4T", "%Cus:ja4.ja4t:0:R",
 	"JA4TS", "%Cus:ja4.ja4ts:0:R",
@@ -50,6 +50,7 @@ Alternatively, they can be added to the preferences by modifiying the user's "pr
 	"JA4X", "%Cus:ja4.ja4x:0:R",
 	"JA4SSH", "%Cus:ja4.ja4ssh:0:R"
 ```
+
 The preference file is located in the following locations:
 #### Windows
 %APPDATA%\Wireshark\preferences


### PR DESCRIPTION
This suggestion is to describe an additional method of adding columns in Wireshark.
... While I myself was configuring Wireshark, I found adding columns in the GUI for preferences to be cumbersome; as a result, I wanted to suggest an alternative method for adding the columns to the documentation. 

TLDR; I updated the instructions to include a means to add multiple columns in a Text Editor, since the Wireshark GUI is cumbersome for anything more than 1 column.