### PR TITLE
ja4: Fix parsing of `tshark --version` output

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.3] - 2024-09-10
+
+### Fixed
+
+- Fix parsing of `tshark --version` output.
+
 ## [0.18.2] - 2024-05-22
 
 ### Fixed

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "ja4"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "clap",
  "color-eyre",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "ja4x"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "clap",
  "color-eyre",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ja4", "ja4x"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.2"
+version = "0.18.3"
 license = "LicenseRef-FoxIO-Proprietary"
 repository = "https://github.com/FoxIO-LLC/ja4"
 

--- a/rust/ja4/src/lib.rs
+++ b/rust/ja4/src/lib.rs
@@ -195,8 +195,9 @@ fn parse_tshark_version(tshark_version_output: &str) -> Option<&str> {
     // "TShark (Wireshark) 4.0.8 (v4.0.8-0-g81696bb74857).\n"
     let start = tshark_version_output.find(") ").map(|i| i + 2)?;
     let version_start = &tshark_version_output[start..];
-    let end = version_start.find(' ')?;
-    Some(&version_start[..end])
+    let end = version_start.find(char::is_whitespace)?;
+    let ver = &version_start[..end];
+    Some(ver.strip_suffix('.').unwrap_or(ver))
 }
 
 #[test]
@@ -209,6 +210,12 @@ fn test_parse_tshark_version() {
         parse_tshark_version("TShark (Wireshark) 3.6.2 (Git v3.6.2 packaged as 3.6.2-2)"),
         Some("3.6.2")
     );
+    assert_eq!(
+        parse_tshark_version("TShark (Wireshark) 4.4.0.\n\nCopyright 1998-2024"),
+        Some("4.4.0")
+    );
+    // Abrupt end of the string.
+    assert!(parse_tshark_version("TShark (Wireshark) 4.4.0.").is_none());
     assert!(parse_tshark_version("What the TShark?!").is_none());
 }
 


### PR DESCRIPTION
## Problem

`cargo test` [fails on CI](https://github.com/FoxIO-LLC/ja4/actions/runs/10798054375/job/29950702492#step:6:287):

```
test tls::tests::test_client_stats_into_out ... ok
test test_insta ... FAILED

failures:

---- test_insta stdout ----
thread 'test_insta' panicked at ja4/src/lib.rs:233:34:
called `Result::unwrap()` on an `Err` value: ParseTsharkSemver(Error("unexpected character '.' after patch version number"))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_insta

test result: FAILED. 16 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s
```

## Analysis

The Rust `ja4` app parses the output of `tshark --version`. The app expected the version number to be followed by a space, e.g. `"TShark (Wireshark) 4.4.0 (v4.4.0-0-g009a163470b5).\n"`. It failed on `"TShark (Wireshark) 4.4.0.\n"`.

## Solution

Improve the parsing logic.