### PR TITLE
CI: Include macOS binaries in Rust apps' releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
           #- { os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
           #- { os: ubuntu-latest, target: aarch64-unknown-linux-gnu }
           #- { os: ubuntu-latest, target: aarch64-unknown-linux-musl }
-          #- { os: macos-latest, target: x86_64-apple-darwin }
-          #- { os: macos-latest, target: aarch64-apple-darwin }
+          - { os: macos-latest, target: x86_64-apple-darwin }
+          - { os: macos-latest, target: aarch64-apple-darwin }
           #- { os: macos-latest, target: universal-apple-darwin }
 
     steps:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "ja4"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "clap",
  "color-eyre",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "ja4x"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "clap",
  "color-eyre",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ja4", "ja4x"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.3"
+version = "0.18.4"
 license = "LicenseRef-FoxIO-Proprietary"
 repository = "https://github.com/FoxIO-LLC/ja4"
 


### PR DESCRIPTION
Bump Rust apps version (0.18.3 -> 0.18.4) to give the `release` CI job an opportunity to run.

Related issue: #154