### PR TITLE
ci (release.yml): Allow missing CHANGELOG.md entry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           changelog: rust/CHANGELOG.md
           token: ${{ secrets.GITHUB_TOKEN }}
+          allow-missing-changelog: true
 
   build-and-upload:
     name: ${{ matrix.job.target }}


### PR DESCRIPTION
In rare cases (e.g. #174) we may want to run the "release" CI job to generate the binaries without making any code changes.