### PR TITLE
Fix a crash bug related to copying strings

### DIFF
--- a/python/ja4x.py
+++ b/python/ja4x.py
@@ -51,9 +51,9 @@ def to_ja4x(x, debug_stream=-1):
     # Get issuer name from CN and ON by scanning the sequence.
     # This is very specific to the way tshark holds the sequence.
     if 'printable_certs' in x:
-        certs = x['printable_certs'].copy()
-        issuers = x['issuers'].copy()
-        subjects = x['subjects'].copy()
+        certs = str(x['printable_certs'])
+        issuers = str(x['issuers'])
+        subjects = str(x['subjects'])
         idx = 1
         for _i, _s in zip(issuers, subjects):
             remove_oids(_i, ['550406', '55040b'])


### PR DESCRIPTION
Fixes this:

```
Traceback (most recent call last):
  File "ja4.py", line 584, in <module>
    main()
  File "ja4.py", line 562, in main
    to_ja4x(x, STREAM)
  File "/tmp/ja4/python/ja4x.py", line 54, in to_ja4x
    certs = x['printable_certs'].copy()
AttributeError: 'str' object has no attribute 'copy'
```