### PR TITLE
Truncate lang component in JA4H fingerprint

### DIFF
--- a/python/ja4h.py
+++ b/python/ja4h.py
@@ -11,6 +11,7 @@ def http_method(method):
 
 def http_language(lang):
     lang = lang.replace('-','').replace(';',',').lower().split(',')[0]
+    lang = lang[:4]
     return f"{lang}{'0'*(4-len(lang))}"
 
 def to_ja4h(x, debug_stream=-1):


### PR DESCRIPTION
Fixes #121

This PR fixes the JA4H fingerprinting in the Python implementation by truncating the lang component (derived from the `Accept-Language` header) to exactly 4 characters. This prevents incorrect fingerprints when the header is malformed or contains unexpected formatting.