### PR TITLE
Add index to JA4 fingerprints

### DIFF
--- a/python/ja4.py
+++ b/python/ja4.py
@@ -253,12 +253,19 @@ def to_ja4(x, debug_stream):
     if ord(alpn[0]) > 127:
         alpn = '99'
 
-    x['JA4'] = f"{ptype}{version}{sni}{cipher_len}{ext_len}{alpn}_{sorted_ciphers}_{sorted_extensions}"
-    x['JA4_o'] = f"{ptype}{version}{sni}{cipher_len}{ext_len}{alpn}_{original_ciphers}_{original_extensions}"
-    x['JA4_r'] = f"{ptype}{version}{sni}{cipher_len}{ext_len}{alpn}_{x['sorted_ciphers']}_{x['sorted_extensions']}"
-    x['JA4_ro'] = f"{ptype}{version}{sni}{cipher_len}{ext_len}{alpn}_{x['original_ciphers']}_{x['original_extensions']}"
+    entry = get_cache(x)[x['stream']]
+    if not entry.get('count'):
+        idx = 0
+    else:
+        idx = entry['count']
+    idx += 1
+    cache_update(x, 'count', idx, debug_stream)
 
-    [ cache_update(x, key, x[key], debug_stream) for key in [ 'domain', 'JA4', 'JA4_r', 'JA4_o', 'JA4_ro'] if key in x ]
+    x[f'JA4.{idx}'] = f"{ptype}{version}{sni}{cipher_len}{ext_len}{alpn}_{sorted_ciphers}_{sorted_extensions}"
+    x[f'JA4_o.{idx}'] = f"{ptype}{version}{sni}{cipher_len}{ext_len}{alpn}_{original_ciphers}_{original_extensions}"
+    x[f'JA4_r.{idx}'] = f"{ptype}{version}{sni}{cipher_len}{ext_len}{alpn}_{x['sorted_ciphers']}_{x['sorted_extensions']}"
+    x[f'JA4_ro.{idx}'] = f"{ptype}{version}{sni}{cipher_len}{ext_len}{alpn}_{x['original_ciphers']}_{x['original_extensions']}"
+    [ cache_update(x, key, x[key], debug_stream) for key in [ 'domain', f'JA4.{idx}', f'JA4_r.{idx}', f'JA4_o.{idx}', f'JA4_ro.{idx}'] if key in x ]
 
 ############ END OF JA4 and JA4S FUNCTIONS #####################
 


### PR DESCRIPTION
Fixes #136
Fixes #183

#### Problem
In the Python implementation of JA4, if multiple fingerprints were present in a single stream, only the last one was retained in the cache, leading to earlier fingerprints being overwritten. As a result, the output contained only the last recorded fingerprint.

#### Solution
We introduced indexing for JA4 fingerprints to ensure all fingerprints from a stream are preserved. Now, fingerprints are stored with numerical suffixes (`.1`, `.2`, etc.), allowing all detected fingerprints to be included in the output.

#### Example Output
```json
{
   "stream": 38,
   "src": "192.168.1.168",
   "dst": "13.107.237.40",
   "srcport": "50159",
   "dstport": "443",
   "domain": "mem.gfx.ms",
   "JA4.1": "t13d1516h2_8daaf6152771_e5627efa2ab1",
   "JA4_r.1": "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0015,0017,001b,0023,002b,002d,0033,4469,ff01_0403,0804,0401,0503,0805,0501,0806,0601",
   "JA4_o.1": "t13d1516h2_acb858a92679_0e6a3d869d9d",
   "JA4_ro.1": "t13d1516h2_1301,1302,1303,c02b,c02f,c02c,c030,cca9,cca8,c013,c014,009c,009d,002f,0035_0005,001b,0033,002d,4469,000a,000d,0012,ff01,000b,0023,002b,0000,0017,0010,0015_0403,0804,0401,0503,0805,0501,0806,0601",
   "JA4.2": "t13d1515h2_8daaf6152771_f37e75b10bcc",
   "JA4_r.2": "t13d1515h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,4469,ff01_0403,0804,0401,0503,0805,0501,0806,0601",
   "JA4_o.2": "t13d1515h2_acb858a92679_b90d13bf6f98",
   "JA4_ro.2": "t13d1515h2_1301,1302,1303,c02b,c02f,c02c,c030,cca9,cca8,c013,c014,009c,009d,002f,0035_0005,001b,0033,002d,4469,000a,000d,0012,ff01,000b,0023,002b,0000,0017,0010_0403,0804,0401,0503,0805,0501,0806,0601"
}
```

This ensures that all fingerprints from a given stream are correctly recorded and available for analysis.