### PR TITLE
Print hex codes for special characters in Accept-Language header

### DIFF
--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -415,19 +415,40 @@ conn_info_t *conn_lookup (char proto, int stream) {
 }
 
 void decode_http_lang(wmem_strbuf_t **out, const char *val) {
-	char lang[5] = "0000"; 
-	int len = 0;
+	wmem_strbuf_t *lang = wmem_strbuf_new(wmem_packet_scope(), "");
+	int count = 0;
 
-	for (int i=0; i<5; i++) {
-		if ((val[i] == ',') || (val[i] == ';') || (len == 4) || (val[i] == '\0')) {
+	// Format the language string
+	for (int i = 0; i < 5; i++) {
+		if ((val[i] == ',') || (val[i] == ';') || (count >= 4) || (val[i] == '\0')) {
 			break;
 		}
-		if ((!g_ascii_isspace(val[i])) && (val[i] != '-')) {
-			lang[len++] = g_ascii_tolower(val[i]);
+		if ((g_ascii_isspace(val[i])) || (val[i] == '-')) {
+			continue;
+		}
+		if (g_ascii_isalpha(val[i]) || g_ascii_isdigit(val[i])) {
+			wmem_strbuf_append_c(lang, g_ascii_tolower(val[i]));
+			count++;
+		}
+		else {
+			// Convert a special character to hex
+			static const char hex[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
+										'8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+			wmem_strbuf_append_c(lang, hex[(val[i] >> 4) & 0xF]);
+			wmem_strbuf_append_c(lang, hex[(val[i] >> 0) & 0xF]);
+			count += 2;
 		}
 	}
 
-	wmem_strbuf_append_printf(*out, "%s", lang);
+	// Ensure we have 4 characters
+	if (count < 4) {
+		wmem_strbuf_append_c_count(lang, '0', 4 - count);
+	}
+	wmem_strbuf_truncate(lang, 4);
+
+	wmem_strbuf_append_printf(*out, "%s", wmem_strbuf_get_str(lang));
+
+	wmem_strbuf_destroy(lang);
 }
 
 void decode_http_version(wmem_strbuf_t **out, const char *val) {


### PR DESCRIPTION
This PR fixes an issue in JA4H fingerprint generation where special characters in the `Accept-Language` header were not handled correctly. Previously, special characters led to incorrect fingerprints, such as:

```
ge11nn07*_4ae0f4a72b53_000000000000_000000000000
```

Now, special characters are encoded using their two-digit hexadecimal ASCII codes, resulting in correct and stable fingerprints. For example, the above fingerprint is now rendered as:

```
ge11nn072a00_4ae0f4a72b53_000000000000_000000000000
```