### PR TITLE
Add HTTP Method Mapping for JA4H Fingerprints

### DIFF
--- a/wireshark/build-scripts/linux_build.sh
+++ b/wireshark/build-scripts/linux_build.sh
@@ -20,6 +20,7 @@ fi
 
 cd wireshark-$VER
 git checkout tags/wireshark-$VER
+rm -rf ./plugins/epan/ja4
 cp -r ../../source ./plugins/epan/ja4
 mv CMakeListsCustom.txt.example CMakeListsCustom.txt
 sed -i "/plugins\/epan\/foo/c\plugins\/epan\/ja4" CMakeListsCustom.txt


### PR DESCRIPTION
This PR introduces a mapping from full HTTP request methods to two-letter JA4H codes, in accordance with the JA4+ specification.

Changes
- Replaces the previous first-two-letters approach with a full method name lookup
- Uses a static lookup table to map methods like `GET`, `POST`, `MKCOL`, etc.
- Falls back to `00` for unrecognized methods