### PR TITLE
Add preference to omit zero cookie hashes in JA4H

### DIFF
--- a/wireshark/README.md
+++ b/wireshark/README.md
@@ -27,6 +27,8 @@ For more details on JA4+ and its implementations in other open-source tools (Pyt
   - [Adding JA4+ Columns in Wireshark](#adding-ja4-columns-in-wireshark)
     - [Method 1: Using Wireshark Preferences UI](#method-1-using-wireshark-preferences-ui)
     - [Method 2: Editing the Preferences File Directly](#method-2-editing-the-preferences-file-directly)
+  - [Available Preferences](#available-preferences)
+    - [Usage in TShark](#usage-in-tshark)
 - [Using a Key File for TLS Decryption](#using-a-key-file-for-tls-decryption)
 - [Testing](#testing)
 - [License](#license)
@@ -200,6 +202,21 @@ Alternatively, you can manually modify Wireshark's **preferences file** using a 
    ```
 
 3. Save the file and restart Wireshark.
+
+### Available Preferences
+
+The JA4+ plugin provides a preference option that controls how certain fingerprint fields are formatted.
+
+- `omit_ja4h_zero_sections`:  
+  If enabled, the plugin omits zeroed JA4H fingerprint sections (`000000000000`) when cookie-related fields are missing.  
+  This makes JA4H output more compact when cookies are not present.
+
+#### Usage in TShark
+
+To enable this option in `tshark`, use the `-o` flag:
+
+```bash
+tshark -o ja4.omit_ja4h_zero_sections:true -r capture.pcap -Y ja4 -T fields -e ja4.ja4h
 
 ## Using a Key File for TLS Decryption
 

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -31,6 +31,7 @@
 #include <epan/epan_dissect.h>
 #include <epan/oids.h>
 #include <epan/tap.h>
+#include <epan/prefs.h>
 //#include <epan/conversation.h>
 //#include <epan/dissectors/packet-tls-utils.h>
 
@@ -84,6 +85,8 @@ static int hf_ja4ts = -1;
 static int dissect_ja4(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *dummy);
 
 static dissector_handle_t ja4_handle;
+
+static bool pref_omit_ja4h_zero_sections = FALSE;
 
 const value_string ssl_versions[] = {
     	{ 0x0002,   "s2" },
@@ -645,7 +648,8 @@ char *ja4h (ja4h_info_t *data) {
 	gchar *hash1 = g_compute_checksum_for_string(G_CHECKSUM_SHA256, wmem_strbuf_get_str(data->headers),-1);
 	gchar *hash2 = g_compute_checksum_for_string(G_CHECKSUM_SHA256, wmem_strbuf_get_str(data->sorted_cookie_fields),-1);
 	gchar *hash3 = g_compute_checksum_for_string(G_CHECKSUM_SHA256, wmem_strbuf_get_str(data->sorted_cookie_values),-1);
-	wmem_strbuf_append_printf(display, "%s%s%s%s%02d%s_%12.12s_%12.12s_%12.12s",
+	const char *zero_hash = pref_omit_ja4h_zero_sections ? "" : "000000000000";
+	wmem_strbuf_append_printf(display, "%s%s%s%s%02d%s_%12.12s_%.12s_%.12s",
 		wmem_strbuf_get_str(data->method),
 		wmem_strbuf_get_str(data->version),
 		data->cookie ? "c" : "n",
@@ -653,8 +657,8 @@ char *ja4h (ja4h_info_t *data) {
 		data->num_headers,
 		wmem_strbuf_get_str(data->lang),
 		hash1,
-		data->cookie ? hash2 : "000000000000",
-		data->cookie ? hash3 : "000000000000"
+		data->cookie ? hash2 : zero_hash,
+		data->cookie ? hash3 : zero_hash
 	);
 	if (hash1 != NULL) g_free(hash1);
 	if (hash2 != NULL) g_free(hash2);
@@ -1575,4 +1579,10 @@ proto_register_ja4(void)
 	register_cleanup_routine(cleanup_globals);
 	//dissector_add_uint("tcp.port", 443, ja4_handle);
 	register_postdissector(ja4_handle);
+
+	module_t *ja4_module = prefs_register_protocol(proto_ja4, NULL);
+	prefs_register_bool_preference(ja4_module, "omit_ja4h_zero_sections",
+		"Omit zero sections in JA4H",
+		"If enabled, zeroed JA4H fingerprint sections (e.g., '000000000000') will be omitted when cookies are missing.",
+		&pref_omit_ja4h_zero_sections);
 }


### PR DESCRIPTION
This PR introduces a new preference option to the JA4+ plugin that allows users to control whether zeroed JA4H fingerprint sections (i.e., `000000000000`) are included when cookies are not present.

### Changes
- Added `omit_ja4h_zero_sections` preference (boolean)
- When enabled and cookies are missing, JA4H will omit the zero hash placeholders
- Switched to `%.12s` formatting for hash fields to avoid padding while keeping them truncated at 12 characters
- Updated JA4H string building logic to respect this new setting

### Usage

**In TShark:**
```bash
tshark -o ja4.omit_ja4h_zero_sections:true -r file.pcap -Y ja4 -T fields -e ja4.ja4h
```

**In Wireshark:**  
Go to `Edit → Preferences → Protocols → JA4` and enable **“Omit zero sections in JA4H”**