### PR TITLE
Add ngrok's JA4 support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This repo includes JA4+ in
 | [AWS WAF](https://aws.amazon.com/about-aws/whats-new/2025/03/aws-waf-ja4-fingerprinting-aggregation-ja3-ja4-fingerprints-rate-based-rules/) | JA4 |
 | [Tacticly](https://tactic.ly/) | JA4+ |
 | [Palo Alto Networks](https://www.paloaltonetworks.com/cortex/cortex-xpanse) | JA4+ (under development) |
+| [ngrok](https://ngrok.com/docs/traffic-policy/variables/connection/#conntlsja4_fingerprint) | JA4 |
 
 with more to be announced...  
 


### PR DESCRIPTION
ngrok recently [added support](https://ngrok.com/blog-post/block-ddos-ja4-fingerprints) for taking action on requests based on their JA4 fingerprint, plus being able to see the fingerprints themselves in the built-in observability tools.

I made the link directly to the docs, but the announcement blog post linked is another option—happy to switch it around if need be.