### PR TITLE
Fix Clippy error by inlining format arguments in the Rust JA4 implementation

### DIFF
--- a/rust/ja4/src/ssh.rs
+++ b/rust/ja4/src/ssh.rs
@@ -278,8 +278,7 @@ impl From<Stats> for Option<Fingerprint> {
         let mode_server = min_key_with_max_value(server_tcp_len_counts).unwrap_or(0);
 
         let fp = format!(
-            "c{mode_client}s{mode_server}_c{}s{}_c{}s{}",
-            nr_ssh_client_packets, nr_ssh_server_packets, nr_tcp_client_acks, nr_tcp_server_acks,
+            "c{mode_client}s{mode_server}_c{nr_ssh_client_packets}s{nr_ssh_server_packets}_c{nr_tcp_client_acks}s{nr_tcp_server_acks}"
         );
         Some(Fingerprint(fp))
     }

--- a/rust/ja4/src/time/tcp.rs
+++ b/rust/ja4/src/time/tcp.rs
@@ -183,8 +183,8 @@ mod state {
             debug_assert!(ja4l_s >= 0); // 0 if the difference == 1
 
             Self::Done(Fingerprints {
-                ja4l_c: format!("{ja4l_c}_{}", client_ttl.0),
-                ja4l_s: format!("{ja4l_s}_{}", server_ttl.0),
+                ja4l_c: format!("{ja4l_c}_{client_ttl}", client_ttl = client_ttl.0),
+                ja4l_s: format!("{ja4l_s}_{server_ttl}", server_ttl = server_ttl.0),
             })
         }
     }

--- a/rust/ja4/src/time/udp.rs
+++ b/rust/ja4/src/time/udp.rs
@@ -234,8 +234,8 @@ mod state {
             debug_assert!(ja4l_s >= 0); // 0 if the difference == 1
 
             Self::Done(Fingerprints {
-                ja4l_c: format!("{ja4l_c}_{}", client_ttl.0),
-                ja4l_s: format!("{ja4l_s}_{}", server_ttl.0),
+                ja4l_c: format!("{ja4l_c}_{client_ttl}", client_ttl = client_ttl.0),
+                ja4l_s: format!("{ja4l_s}_{server_ttl}", server_ttl = server_ttl.0),
             })
         }
     }

--- a/rust/ja4/src/tls.rs
+++ b/rust/ja4/src/tls.rs
@@ -463,7 +463,7 @@ impl ServerStats {
 
         OutServer {
             pkt_ja4s: packet,
-            ja4s: format!("{two_chunks}_{}", crate::hash12(&exts)),
+            ja4s: format!("{two_chunks}_{hash}", hash = crate::hash12(&exts)),
             ja4s_r: flags.with_raw.then(|| format!("{two_chunks}_{exts}")),
         }
     }

--- a/rust/ja4x/src/main.rs
+++ b/rust/ja4x/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> eyre::Result<()> {
         } else {
             tracing::debug!(?path, format = "DER");
             let (rem, x509) = X509Certificate::from_der(&buf)
-                .wrap_err_with(|| format!("{}: unsupported file format", path.display()))
+                .wrap_err_with(|| format!("{path}: unsupported file format", path = path.display()))
                 .suggestion("please provide DER- or PEM-encoded certificate")?;
             debug_assert!(rem.is_empty());
             ja4x::X509Rec::from(x509)


### PR DESCRIPTION
This PR fixes a Clippy error that occurs under the Rust **beta toolchain**, where `format!` was used with positional arguments instead of inlined named variables.

```text
error: variables can be used directly in the `format!` string
   --> ja4/src/ssh.rs:280:18
    |
280 |     let fp = format!("c{mode_client}s{mode_server}_c{}s{}_c{}s{}\", nr_ssh_client_packets, nr_ssh_server_packets, nr_tcp_client_acks, nr_tcp_server_acks);
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
```

### Changes:

* Replaced `format!(...)` calls with inlined named variables (`format!("{foo}")` style) as recommended by Clippy.
* Ensures compatibility with `-D warnings` on Rust beta and future toolchains.

No functional changes - this is a formatting-only fix to satisfy stricter Clippy checks.