### PR TITLE
Wireshark: correct wmem_array creation

### DIFF
--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -763,7 +763,7 @@ static int dissect_ja4(tvbuff_t *tvb, packet_info *pinfo _U_, proto_tree *tree, 
     // For JA4X
     guint cert_num = -1;
     guint oid_type = -1;
-    wmem_array_t *certificate_list = wmem_array_new(wmem_packet_scope(), 100);
+    wmem_array_t *certificate_list = wmem_array_sized_new(pinfo->pool, sizeof(cert_t), 100);
 
     // For JA4H
     gchar **strings;


### PR DESCRIPTION
The second argument to `wmem_array_new()` is the size of each element in the array. The hardcoded value of 100 used in `packet-ja4.c` can cause runtime errors on some platforms about its values not being properly aligned in memory to the platform's word size.

Assuming that 100 was meant to be the number of elements to pre-allocate in the new array, replace `wmem_array_new()` with `wmem_array_sized_new()` with 100 as the third argument (and a `sizeof` the element as the second).

Built and tested as an in-tree build on Windows 11 against Wireshark's `master` branch. Ran the test framework from #222 before and after making my changes, to validate that the output does not change.