### PR TITLE
Remove application handshake latency from JA4L for HTTP requests

### DIFF
--- a/wireshark/test/testdata/latest.pcapng.json
+++ b/wireshark/test/testdata/latest.pcapng.json
@@ -277,6 +277,24 @@
     "_source": {
       "layers": {
         "frame.number": [
+          "116"
+        ],
+        "ja4.ja4l": [
+          "32_128_tcp"
+        ],
+        "ja4.ja4ls": [
+          "3915_57_tcp"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2023-06-23",
+    "_type": "doc",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
           "117"
         ],
         "ja4.ja4l": [

--- a/wireshark/test/testdata/ssh2.pcapng.json
+++ b/wireshark/test/testdata/ssh2.pcapng.json
@@ -695,6 +695,24 @@
     "_source": {
       "layers": {
         "frame.number": [
+          "376"
+        ],
+        "ja4.ja4l": [
+          "45_128_tcp"
+        ],
+        "ja4.ja4ls": [
+          "6252_58_tcp"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2023-07-06",
+    "_type": "doc",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
           "460"
         ],
         "ja4.ja4t": [
@@ -975,6 +993,24 @@
         ],
         "ja4.ja4h_ro": [
           "ge11nn030000_Connection,User-Agent,Host__"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2023-07-06",
+    "_type": "doc",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
+          "958"
+        ],
+        "ja4.ja4l": [
+          "50_128_tcp"
+        ],
+        "ja4.ja4ls": [
+          "4272_58_tcp"
         ]
       }
     }

--- a/wireshark/test/testdata/tls3.pcapng.json
+++ b/wireshark/test/testdata/tls3.pcapng.json
@@ -105,6 +105,24 @@
     "_source": {
       "layers": {
         "frame.number": [
+          "80"
+        ],
+        "ja4.ja4l": [
+          "14_128_tcp"
+        ],
+        "ja4.ja4ls": [
+          "3181_57_tcp"
+        ]
+      }
+    }
+  },
+  {
+    "_index": "packets-2023-08-24",
+    "_type": "doc",
+    "_score": null,
+    "_source": {
+      "layers": {
+        "frame.number": [
           "81"
         ],
         "ja4.ja4l": [


### PR DESCRIPTION
This PR updates the JA4L logic to detect when packets following the TCP handshake contain the HTTP protocol. In such cases, application latency cannot be reliably measured, so the JA4L and JA4LS fingerprints are formatted using `_tcp` as a suffix to indicate pure TCP timing only (e.g., `45_128_tcp`).