### PR TITLE
suggestions for Zeek scripts

### DIFF
--- a/zeek/ja4/main.zeek
+++ b/zeek/ja4/main.zeek
@@ -120,12 +120,12 @@ function make_a(c: connection): string {
 
 # Produce the JA4_b hash value
 function b_hash(input: vector of count): string {
-  return FINGERPRINT::sha256_12(FINGERPRINT::vector_of_count_to_str(input));
+  return FINGERPRINT::sha256_or_null__12(FINGERPRINT::vector_of_count_to_str(input));
 }
 
 # Produce the JA4_c hash value
 function c_hash(input: string): string {  
-  return FINGERPRINT::sha256_12(input);
+  return FINGERPRINT::sha256_or_null__12(input);
 }
 
 function do_ja4(c: connection) {

--- a/zeek/ja4/main.zeek
+++ b/zeek/ja4/main.zeek
@@ -78,9 +78,7 @@ function make_a(c: connection): string {
     #  Doign that would require checking that the string has a value TLD, a valid number of 
     #  subdomains, only valid characters, and likely other checks too.
     #  Consider the example SNI value of "foo.localhost", it's not a real domain but is also not an IP address
-    if (c$fp$client_hello$sni[0] != fmt("%s", c$id$resp_h)) {
       sni = "d";
-    }
   }
 
   local alpn: string = "00";

--- a/zeek/ja4h/main.zeek
+++ b/zeek/ja4h/main.zeek
@@ -192,23 +192,15 @@ event http_message_done(c: connection, is_orig: bool, stat: http_message_stat)
     local ja4h_a = get_ja4h_a(c);
     local ja4h_b_o = FINGERPRINT::vector_of_str_to_str(c$fp$http_client$header_names_o);
     local ja4h_b_r = FINGERPRINT::vector_of_str_to_str(c$fp$http_client$header_names);
-    local ja4h_b = FINGERPRINT::sha256_12(ja4h_b_r);
+    local ja4h_b = FINGERPRINT::sha256_or_null__12(ja4h_b_r);
     local ja4h_c_o = FINGERPRINT::vector_of_str_to_str(c$fp$http_client$cookie_names);
     local ja4h_c_r = get_ja4h_c(c);  
     local ja4h_c: string;
-    if (ja4h_c_r == "") {
-        ja4h_c = "000000000000";
-    } else {
-        ja4h_c = FINGERPRINT::sha256_12(ja4h_c_r);
-    }
+    ja4h_c = FINGERPRINT::sha256_or_null__12(ja4h_c_r);
     local ja4h_d_o = FINGERPRINT::vector_of_str_to_str(c$fp$http_client$cookie_values);
     local ja4h_d_r = get_ja4h_d(c);
     local ja4h_d: string;
-    if (ja4h_d_r == "") {
-        ja4h_d = "000000000000";
-    } else {
-        ja4h_d = FINGERPRINT::sha256_12(ja4h_d_r);
-    }
+    ja4h_d = FINGERPRINT::sha256_or_null__12(ja4h_d_r);
     local delim =  FINGERPRINT::delimiter;
 
     c$fp$ja4h$uid = c$uid;  

--- a/zeek/ja4s/main.zeek
+++ b/zeek/ja4s/main.zeek
@@ -142,7 +142,7 @@ function do_ja4s(c: connection) {
 
   c$fp$ja4s$uid = c$uid;  
   c$fp$ja4s$r = ja4s_a + delim + ja4s_b + delim + ja4s_c;
-  c$fp$ja4s$ja4s = ja4s_a + delim + ja4s_b + delim + FINGERPRINT::sha256_12(ja4s_c);
+  c$fp$ja4s$ja4s = ja4s_a + delim + ja4s_b + delim + FINGERPRINT::sha256_or_null__12(ja4s_c);
 
   if(c?$ssl) {
     c$ssl$ja4s = c$fp$ja4s$ja4s;

--- a/zeek/ja4s/main.zeek
+++ b/zeek/ja4s/main.zeek
@@ -47,6 +47,8 @@ export {
     extension_codes: vector of count &default=vector();
 
     alpn: string &default = "00";
+
+    is_complete: bool &default=F;
   };
 }
 
@@ -74,9 +76,13 @@ event zeek_init() &priority=5 {
 event ssl_server_hello(c: connection, version: count, record_version: count, possible_ts: time, 
   server_random: string, session_id: string, cipher: count, comp_method: count) {
   if(!c?$fp) { c$fp = FINGERPRINT::Info(); }
+  if(c$fp$server_hello$is_complete) { return; }
   
-  c$fp$server_hello$version =  version;
+  if (!c$fp$server_hello?$version) {
+    c$fp$server_hello$version = version;
+  }
   c$fp$server_hello$cipher = cipher;
+  c$fp$server_hello$is_complete = T;
 }
 
 # For each extension, ignoring GREASE, build up an array of code in the order they appear
@@ -84,6 +90,7 @@ event ssl_extension(c: connection, is_client: bool, code: count, val: string) {
   if(!c?$fp) { c$fp = FINGERPRINT::Info(); }
   if (code in FINGERPRINT::TLS_GREASE_TYPES) { return; }  # Will we see grease from the server?
   if (!is_client) {
+    if(c$fp$server_hello$is_complete) { return; }
     c$fp$server_hello$extension_codes += code;
   }
 }
@@ -92,9 +99,28 @@ event ssl_extension(c: connection, is_client: bool, code: count, val: string) {
 event ssl_extension_application_layer_protocol_negotiation(c: connection, is_client: bool, protocols: string_vec) {
   if(!c?$fp) { c$fp = FINGERPRINT::Info(); }
   if (!is_client && |protocols| > 0) {
+    if(c$fp$server_hello$is_complete) { return; }
     # NOTE:  Assumes the server only returns one ALPN, there might be a bypass if multiple are returned and the last
     # or a random one is used
     c$fp$server_hello$alpn = protocols[0];
+  }
+}
+
+# If the supported versions extension is present, find the largest offered version and store it
+event ssl_extension_supported_versions(c: connection, is_client: bool, versions: index_vec) {
+  if(!c?$fp) { c$fp = FINGERPRINT::Info(); }
+  if (!is_client) {
+    local largest: count = 0;
+    for (idx in versions) {
+      local val = versions[idx];
+      if (val in FINGERPRINT::TLS_GREASE_TYPES) {
+        next;
+      }
+      if (val > largest) {
+        largest = val;
+      }
+    }
+    c$fp$server_hello$version = largest;
   }
 }
 

--- a/zeek/utils/common.zeek
+++ b/zeek/utils/common.zeek
@@ -12,8 +12,8 @@ export {
     # Sort a vector of count by the count values
     global order_vector_of_count: function (input: vector of count): vector of count;
 
-    # Produce the hash value
-    global sha256_12: function (input: string): string;
+    # Produce the hash value (or 000000000000 for empty string)
+    global sha256_or_null__12: function (input: string): string;
 
 }
 
@@ -56,8 +56,11 @@ function order_vector_of_count(input: vector of count): vector of count {
     return outvec;
 }
 
-# Produce the hash value
-function sha256_12(input: string): string {
+# Produce the hash value (or 000000000000 for empty string)
+function sha256_or_null__12(input: string): string {
+    if (input == "") {
+        return "000000000000";
+    }
     local sha256_object = sha256_hash_init();
     sha256_hash_update(sha256_object, input);
     return sha256_hash_finish(sha256_object)[:12];


### PR DESCRIPTION
These suggestions would update the Zeek scripts to more closely match the current JA4 specification, making its output more consistent with the Python, Rust, and Wireshark plugins.

*    Output 000000000000 instead of hashing empty string
     Example: https://github.com/zeek/zeek/blob/master/testing/btest/Traces/tls/ssl.v3.trace
     `t10i200000_6c5778701a4a_000000000000` is the JA4 reported by Wireshark.
     `t10i200000_6c5778701a4a_e3b0c44298fc` is the JA4 reported by Zeek.

*    Output dtls protocol
     Example: https://github.com/FoxIO-LLC/ja4/raw/refs/heads/main/pcap/dtls-udp.notest.cap
     `dd1i440200_49bcda3e7ebf_18d1e47e0978` is the JA4 in Wireshark (built-in, not FoxIO plugin)
     `td1i440200_49bcda3e7ebf_18d1e47e0978` is the JA4 from the FoxIO Zeek plugin.

*    Use supported version extension
     Example: https://github.com/FoxIO-LLC/ja4/blob/main/pcap/http2-with-cookies.pcapng
     `t130200_1301_234ea6891581` Rust
     `t120200_1301_234ea6891581` Zeek

*    Use values from first clienthello/serverhello only
     Example: https://github.com/zeek/zeek/blob/master/testing/btest/Traces/tls/hrr.pcap
     `t13i040900_16476d049b0b_78f1d400d464` is the JA4 calculated by Wireshark and FoxIO's Python script.
     `t13i041800_16476d049b0b_09276b690d57` is the value calculated by Zeek.