### PR TITLE
Fix mismatched lifetime warning

### DIFF
--- a/rust/ja4/src/pcap.rs
+++ b/rust/ja4/src/pcap.rs
@@ -63,7 +63,7 @@ impl<'a> Packet<'a> {
     }
 
     /// Returns an iterator over the [`Proto`]cols of this packet.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = Proto> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = Proto<'_>> {
         self.inner.iter().map(|layer| Proto {
             inner: layer,
             packet_num: self.num,


### PR DESCRIPTION
Fix the following Rust 2021 mismatched-lifetime warning in `iter()` by
using an explicit `'_` lifetime in the return type:

```
error: hiding a lifetime that's elided elsewhere is confusing
  --> ja4/src/pcap.rs:66:24
   |
66 |     pub(crate) fn iter(&self) -> impl Iterator<Item = Proto> {
   |                        ^^^^^                          ----- the same lifetime is hidden here
   |                        |
   |                        the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: use `'_` for type paths
   |
66 |     pub(crate) fn iter(&self) -> impl Iterator<Item = Proto<'_>> {
   |                                                            ++++
```