### PR TITLE
Reapply tap workaround for columns

### DIFF
--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -1600,18 +1600,12 @@ static ja4_tap_t const ja4_taps[] = {
     {"frame", &hf_ja4s,              NULL                 },
     {"frame", &hf_ja4s_raw,          NULL                 },
 
-    {TLS_TAP, &hf_ja4x,              "tls.handshake.type == 11"                },
-    {TLS_TAP, &hf_ja4x_raw,          "tls.handshake.type == 11"                },
+    {"frame", &hf_ja4x,              NULL                },
+    {"frame", &hf_ja4x_raw,          NULL                },
 
-    {"dtls",  &hf_ja4x,              "dtls.handshake.type == 11"               },
-    {"dtls",  &hf_ja4x_raw,          "dtls.handshake.type == 11"               },
-
-    {"http",  &hf_ja4h,              NULL                                      },
-    {"http",  &hf_ja4h_raw,          NULL                                      },
-    {"http",  &hf_ja4h_raw_original, NULL                                      },
-    {"http2", &hf_ja4h,              NULL                                      },
-    {"http2", &hf_ja4h_raw,          NULL                                      },
-    {"http2", &hf_ja4h_raw_original, NULL                                      },
+    {"frame",  &hf_ja4h,              NULL                                      },
+    {"frame",  &hf_ja4h_raw,          NULL                                      },
+    {"frame",  &hf_ja4h_raw_original, NULL                                      },
     {"frame",   &hf_ja4l,              NULL                      },
     {"tcp",   &hf_ja4l_delta,        "tcp.flags == 0x018"                      },
     {"frame",   &hf_ja4ls,           NULL                      },

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -1597,25 +1597,29 @@ typedef struct ja4_tap_s {
 #endif
 
 static ja4_tap_t const ja4_taps[] = {
-    {"frame", &hf_ja4s,              NULL                 },
-    {"frame", &hf_ja4s_raw,          NULL                 },
+    {"frame", &hf_ja4s,               NULL},
+    {"frame", &hf_ja4s_raw,           NULL},
 
-    {"frame", &hf_ja4x,              NULL                },
-    {"frame", &hf_ja4x_raw,          NULL                },
+    {"frame", &hf_ja4x,               NULL},
+    {"frame", &hf_ja4x_raw,           NULL},
 
-    {"frame",  &hf_ja4h,              NULL                                      },
-    {"frame",  &hf_ja4h_raw,          NULL                                      },
-    {"frame",  &hf_ja4h_raw_original, NULL                                      },
-    {"frame",   &hf_ja4l,              NULL                      },
-    {"frame",   &hf_ja4l_delta,        NULL                      },
-    {"frame",   &hf_ja4ls,           NULL                      },
-    {"frame",   &hf_ja4ls_delta,       NULL                     },
-    {"frame",   &hf_ja4ssh,            NULL                           },
-    {"frame",   &hf_ja4t,              NULL                      },
-    {"frame",   &hf_ja4ts,             NULL},
-    {"frame", &hf_ja4d,             NULL                                      },
+    {"frame", &hf_ja4h,               NULL},
+    {"frame", &hf_ja4h_raw,           NULL},
+    {"frame", &hf_ja4h_raw_original,  NULL},
 
-    {NULL,    NULL,                  NULL                                      }  // keep this at the end
+    {"frame", &hf_ja4l,               NULL},
+    {"frame", &hf_ja4l_delta,         NULL},
+    {"frame", &hf_ja4ls,              NULL},
+    {"frame", &hf_ja4ls_delta,        NULL},
+
+    {"frame", &hf_ja4ssh,             NULL},
+
+    {"frame", &hf_ja4t,               NULL},
+    {"frame", &hf_ja4ts,              NULL},
+
+    {"frame", &hf_ja4d,               NULL},
+
+    {NULL,    NULL,                   NULL} // keep this at the end
 };
 
 // Add missing declaration so init/cleanup can reference it

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -1281,7 +1281,6 @@ static int dissect_ja4(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void
 
                                     double delta = (double)latency2.nsecs / (double)latency.nsecs;
                                     delta = round(delta * 10.0) / 10.0;
-                                    ws_warning("Delta: %f", delta);
                                     update_tree_item(
                                         pinfo->num, tvb, tree, &ja4_tree, hf_ja4ls_delta,
                                         &delta, "tcp"
@@ -1617,7 +1616,9 @@ static ja4_tap_t const ja4_taps[] = {
     {"http2", &hf_ja4h_raw,          NULL                                      },
     {"http2", &hf_ja4h_raw_original, NULL                                      },
     {"tcp",   &hf_ja4l,              "tcp.flags == 0x018"                      },
+    {"tcp",   &hf_ja4l_delta,        "tcp.flags == 0x018"                      },
     {"tcp",   &hf_ja4ls,             "tcp.flags == 0x018"                      },
+    {"tcp",   &hf_ja4ls_delta,       "tcp.flags == 0x018"                      },
     {"tcp",   &hf_ja4ssh,            "ssh.direction"                           },
     {"tcp",   &hf_ja4t,              "tcp.flags == 0x002"                      },
     {"tcp",   &hf_ja4ts,             "tcp.flags == 0x012 || tcp.flags == 0x004"},

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -1597,11 +1597,8 @@ typedef struct ja4_tap_s {
 #endif
 
 static ja4_tap_t const ja4_taps[] = {
-    {TLS_TAP, &hf_ja4s,              "tls.handshake.type == 2"                 },
-    {TLS_TAP, &hf_ja4s_raw,          "tls.handshake.type == 2"                 },
-
-    {"dtls",  &hf_ja4s,              "dtls.handshake.type == 2"                },
-    {"dtls",  &hf_ja4s_raw,          "dtls.handshake.type == 2"                },
+    {"frame", &hf_ja4s,              NULL                 },
+    {"frame", &hf_ja4s_raw,          NULL                 },
 
     {TLS_TAP, &hf_ja4x,              "tls.handshake.type == 11"                },
     {TLS_TAP, &hf_ja4x_raw,          "tls.handshake.type == 11"                },
@@ -1615,14 +1612,14 @@ static ja4_tap_t const ja4_taps[] = {
     {"http2", &hf_ja4h,              NULL                                      },
     {"http2", &hf_ja4h_raw,          NULL                                      },
     {"http2", &hf_ja4h_raw_original, NULL                                      },
-    {"tcp",   &hf_ja4l,              "tcp.flags == 0x018"                      },
+    {"frame",   &hf_ja4l,              NULL                      },
     {"tcp",   &hf_ja4l_delta,        "tcp.flags == 0x018"                      },
-    {"tcp",   &hf_ja4ls,             "tcp.flags == 0x018"                      },
+    {"frame",   &hf_ja4ls,           NULL                      },
     {"tcp",   &hf_ja4ls_delta,       "tcp.flags == 0x018"                      },
-    {"tcp",   &hf_ja4ssh,            "ssh.direction"                           },
+    {"frame",   &hf_ja4ssh,            NULL                           },
     {"tcp",   &hf_ja4t,              "tcp.flags == 0x002"                      },
     {"tcp",   &hf_ja4ts,             "tcp.flags == 0x012 || tcp.flags == 0x004"},
-    {"dhcp",  &hf_ja4d,              NULL                                      },
+    {"frame", &hf_ja4d,             NULL                                      },
 
     {NULL,    NULL,                  NULL                                      }  // keep this at the end
 };
@@ -1652,7 +1649,7 @@ static void init_globals(void) {
         active_taps = g_ptr_array_sized_new(array_length(ja4_taps));
         for (i = 0; ja4_taps[i].hfid != NULL; i++) {
             ret = register_tap_listener(
-                ja4_taps[i].tap, ja4_taps[i].hfid, ja4_taps[i].filter, TL_REQUIRES_PROTO_TREE, NULL,
+                "frame", ja4_taps[i].hfid, NULL, TL_REQUIRES_PROTO_TREE, NULL,
                 tap_all, NULL, NULL
             );
             if (ret == NULL) {

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -1594,8 +1594,11 @@ static tap_packet_status tap_all(
     tap_flags_t flags _U_
 ) {
     g_warning("JA4H tap display count: %d", tap_display_count++);
-    display_hashes_from_packet_table(*(int *)tapdata, edt->tree, edt->tvb, pinfo->num);
-    return TAP_PACKET_REDRAW;
+    int added = display_hashes_from_packet_table(*(int *)tapdata, edt->tree, edt->tvb, pinfo->num);
+    if (added > 0) {
+        return TAP_PACKET_REDRAW;
+    }
+    return TAP_PACKET_DONT_REDRAW;;
 }
 
 typedef struct ja4_tap_s {

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -1607,12 +1607,12 @@ static ja4_tap_t const ja4_taps[] = {
     {"frame",  &hf_ja4h_raw,          NULL                                      },
     {"frame",  &hf_ja4h_raw_original, NULL                                      },
     {"frame",   &hf_ja4l,              NULL                      },
-    {"tcp",   &hf_ja4l_delta,        "tcp.flags == 0x018"                      },
+    {"frame",   &hf_ja4l_delta,        NULL                      },
     {"frame",   &hf_ja4ls,           NULL                      },
-    {"tcp",   &hf_ja4ls_delta,       "tcp.flags == 0x018"                      },
+    {"frame",   &hf_ja4ls_delta,       NULL                     },
     {"frame",   &hf_ja4ssh,            NULL                           },
-    {"tcp",   &hf_ja4t,              "tcp.flags == 0x002"                      },
-    {"tcp",   &hf_ja4ts,             "tcp.flags == 0x012 || tcp.flags == 0x004"},
+    {"frame",   &hf_ja4t,              NULL                      },
+    {"frame",   &hf_ja4ts,             NULL},
     {"frame", &hf_ja4d,             NULL                                      },
 
     {NULL,    NULL,                  NULL                                      }  // keep this at the end

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -354,9 +354,8 @@ display_hashes_from_packet_table(proto_tree *tree, tvbuff_t *tvb, int frame_numb
         proto_tree *sub_tree = NULL;
         proto_tree *child = tree_location->first_child;
         while (child) {
-            if (child->finfo->hfinfo &&
-                (strcmp(child->finfo->hfinfo->abbrev, "ja4") == 0 ||
-                 strncmp(child->finfo->hfinfo->abbrev, "ja4.", 4) == 0)) {
+            if (child->finfo->hfinfo && (strcmp(child->finfo->hfinfo->abbrev, "ja4") == 0 ||
+                                         strncmp(child->finfo->hfinfo->abbrev, "ja4.", 4) == 0)) {
                 // Found an existing JA4 subtree
                 sub_tree = child;
                 break;
@@ -983,7 +982,6 @@ static int dissect_ja4(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void
             }
 
             // Added for JA4H - HTTP1.0 and 1.1
-
             static const struct {
                 const char *method;
                 const char *code;

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -313,7 +313,7 @@ pkt_info_t *packet_table_lookup(int frame_number) {
 
 // Replace the existing update_tree_item with the packet table version
 void update_tree_item(
-    int frame_number, tvbuff_t *tvb _U_, proto_tree *tree, proto_tree **ja4_tree _U_, int field,
+    int frame_number, tvbuff_t *tvb _U_, proto_tree *tree _U_, proto_tree **ja4_tree _U_, int field,
     const void *data, const char *insert_at
 ) {
     // Store in packet table for column display
@@ -1576,9 +1576,6 @@ static tap_packet_status tap_all(
     return TAP_PACKET_DONT_REDRAW;;
 }
 
-
-// Add missing declaration so init/cleanup can reference it
-static GPtrArray *active_taps = NULL;
 static int frame_tapdata = -1;
 
 static void init_globals(void) {
@@ -1597,10 +1594,11 @@ static void init_globals(void) {
     packet_table = wmem_map_new_autoreset(wmem_epan_scope(), wmem_file_scope(), g_direct_hash, g_direct_equal);
 
     if (proto_is_protocol_enabled(find_protocol_by_id(proto_ja4))) {
-        GString *ret;
-        size_t i;
-
-        ret = register_tap_listener("frame", &frame_tapdata, NULL, TL_REQUIRES_PROTO_TREE, NULL, tap_all, NULL, NULL);
+        GString *ret = register_tap_listener("frame", &frame_tapdata, NULL, TL_REQUIRES_PROTO_TREE, NULL, tap_all, NULL, NULL);
+        if (ret != NULL) {
+            g_warning("JA4: Unable to register tap listener: %s\n", ret->str);
+            g_string_free(ret, TRUE);
+        }
     }
 }
 

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -297,7 +297,7 @@ pkt_info_t *packet_table_lookup(int frame_number) {
     pkt_info_t *data = wmem_map_lookup(packet_table, GINT_TO_POINTER(frame_number));
     if (data == NULL) {
         data = wmem_new0(wmem_file_scope(), pkt_info_t);
-        data->pkt_hashes = wmem_array_new(wmem_file_scope(), 100);
+        data->pkt_hashes = wmem_array_new(wmem_file_scope(), sizeof(packet_hash_t));
         data->frame_number = frame_number;
         data->num_of_hashes = 0;
         data->complete = false;

--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -55,10 +55,6 @@ static inline const guint8 *field_bytes(fvalue_t const *fv) {
 #endif
 }
 
-char *bytes_to_string(fvalue_t *fv) {
-    return fvalue_to_string_repr(wmem_packet_scope(), fv, FTREPR_DISPLAY, 0);
-}
-
 static int proto_ja4;
 static int proto_http;
 static gint ett_ja4 = -1;


### PR DESCRIPTION
Fixes #235.

In #226 we removed a tap listener. As a result, JA4 fingerprints stopped appearing in Wireshark columns, even though they still show up in the Info pane and in tshark. This is due to how post-dissectors interact with Wireshark’s column population - columns may not be filled unless a tap drives the updates.

This PR reintroduces the tap-based workaround to ensure JA4 fields are again visible in columns. It’s a temporary fix and can be removed once Wireshark consistently supports column population from post-dissectors.