### PR TITLE
Fix Wireshark crash when following TCP stream with JA4 plugin

### DIFF
--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -363,6 +363,10 @@ display_hashes_from_packet_table(proto_tree *tree, tvbuff_t *tvb, int frame_numb
             sub_tree = proto_item_add_subtree(ja4_ti, ett_ja4);
         }
         
+        if (sub_tree == NULL || sub_tree->finfo->tree_type == -1) {
+            return 0;
+        }
+
         for (int i = 0; i < pi->num_of_hashes; i++) {
             packet_hash_t *hash = (packet_hash_t *)wmem_array_index(pi->pkt_hashes, i);
             if (hash->hf_type == FT_DOUBLE) {


### PR DESCRIPTION
Fixes #256

This PR fixes a crash that occurred in the Wireshark GUI when using **Follow -> TCP Stream** with the JA4 plugin installed.

### Root cause:

`display_hashes_from_packet_table()` could attempt to add fields under an invalid or incomplete subtree. When the GUI later traversed this subtree (e.g. during stream follow), Wireshark crashed.

### Verification:

* `wireshark -r http1.pcapng` -> no crash on **Follow TCP Stream**
* Cannot be tested in CI, as the crash is not reproducible with `tshark` (it doesn’t access GUI display-tree paths)