### PR TITLE
Wireshark: style tweaks akin to Wireshark practices

### DIFF
--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -55,24 +55,24 @@ static inline const uint8_t *field_bytes(fvalue_t const *fv) {
 #endif
 }
 
-static int proto_ja4;
-static int proto_http;
-static int ett_ja4;
-static int hf_ja4s_raw;
-static int hf_ja4s;
-static int hf_ja4x_raw;
-static int hf_ja4x;
-static int hf_ja4h;
-static int hf_ja4h_raw;
-static int hf_ja4h_raw_original;
-static int hf_ja4l;
-static int hf_ja4l_delta;
-static int hf_ja4ls;
-static int hf_ja4ls_delta;
-static int hf_ja4ssh;
-static int hf_ja4t;
-static int hf_ja4ts;
-static int hf_ja4d;
+static int proto_ja4 = -1;
+static int proto_http = -1;
+static int ett_ja4 = -1;
+static int hf_ja4s_raw = -1;
+static int hf_ja4s = -1;
+static int hf_ja4x_raw = -1;
+static int hf_ja4x = -1;
+static int hf_ja4h = -1;
+static int hf_ja4h_raw = -1;
+static int hf_ja4h_raw_original = -1;
+static int hf_ja4l = -1;
+static int hf_ja4l_delta = -1;
+static int hf_ja4ls = -1;
+static int hf_ja4ls_delta = -1;
+static int hf_ja4ssh = -1;
+static int hf_ja4t = -1;
+static int hf_ja4ts = -1;
+static int hf_ja4d = -1;
 
 static int dissect_ja4(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *dummy);
 


### PR DESCRIPTION
Some minor tweaks to the coding style of the Wireshark dissector to bring it closer to the standard practices used in the Wireshark project itself. All changes are compatible with Wireshark 4.6 and should be with 4.4 as well.

Define `WS_LOG_DOMAIN`. Allows for more targeted showing/hiding of [log messages](https://www.wireshark.org/docs/wsdg_html/#ChSrcLogging). Use `ws_warning()` instead of `g_warning()` to leverage.

Correct spelling of `MAX_SSL_VERSION()` macro.

Run script through Wireshark's `tools/convert-glib-types.py` to replace GLib-specific types with C99 standard types (ref Wireshark [#19116](https://gitlab.com/wireshark/wireshark/-/issues/19116)).

Make every global variable and every function (except the register and handoff functions) static, since none of them are used outside of this plugin.

Remove constant `HFIDS` and instead define `interesting_hfids[]` as having an indefinite number of elements. Use the `array_length()` macro instead for determining the size of the array. It's still calculated at compile time, and removes a potential source of bugs if elements are added to or removed from `interesting_hfids[]` in future changes.

Add `g_strfreev()` calls to correspond with each call to `g_strsplit()`, which specifies in its
[documentation](https://docs.gtk.org/glib/func.strsplit.html) that its return value must be freed.