### PR TITLE
Doc updates to include additional ALPN extension values

### DIFF
--- a/technical_details/JA4.md
+++ b/technical_details/JA4.md
@@ -83,7 +83,7 @@ Same as counting ciphers. Ignore GREASE. Include SNI and ALPN.
 
 ### ALPN Extension Value
 
-The first and last ASCII alphanumeric characters of the ALPN (Application-Layer Protocol Negotiation) first value.
+The first and last ASCII alphanumeric characters of the ALPN (Application-Layer Protocol Negotiation) first value.  
 List of possible ALPN Values (scroll down): https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml
 
 In the above example, the first ALPN value is h2 so the first and last characters to use in the fingerprint are “h2”. If the first ALPN listed was http/1.1 then the first and last characters to use in the fingerprint would be “h1”.


### PR DESCRIPTION
### Overview
Adding examples to cover space character (`sp`, `0x20`) handling in the ALPN Extension Value as we have seen some unexpected JA4 fingerprints in Wireshark when a space character is sent by the client.

ℹ️ Please note, I have also raised an issue over on the Wireshark repo to highlight what we have seen: https://gitlab.com/wireshark/wireshark/-/issues/20966 

### Example 1
ALPN Extension Value sent by client:
```bash
ALPN Next Protocol: ' ' 
Hex values: 0x20
```
Resulting JA4 Fingerprint (Note: double space in place of ALPN value)
```bash
t13d0808  _b83013aef563_36a8af52ae46
```

Expected JA4 Fingerprint
```bash
t13d080820_b83013aef563_36a8af52ae46
```

### Example 2
ALPN Extension Value sent by client:
```bash
ALPN Next Protocol: 'a ' 
Hex values: 0x61 0x20
```
Resulting JA4 Fingerprint (Note: sinlge space set for second ALPN value)
```bash
t13d0808a _b83013aef563_36a8af52ae46
```

Expected JA4 Fingerprint
```bash
t13d080860_b83013aef563_36a8af52ae46
```