### PR TITLE
Fix JA4SSH SSH detection, direction handling, and ACK counting in the Python implementation

### DIFF
--- a/python/test/testdata/ssh-r.pcap.json
+++ b/python/test/testdata/ssh-r.pcap.json
@@ -16,7 +16,7 @@
             "ssh_protocol_server": "SSH-2.0-OpenSSH_8.7",
             "encryption_algorithm": "aes256-gcm@openssh.com"
         },
-        "JA4SSH.1": "c64s64_c6s5_c0s0"
+        "JA4SSH.1": "c64s64_c6s5_c4s5"
     },
     {
         "stream": 2,
@@ -35,11 +35,11 @@
             "ssh_protocol_server": "SSH-2.0-OpenSSH_8.7",
             "encryption_algorithm": "aes256-gcm@openssh.com"
         },
-        "JA4SSH.1": "c64s64_c104s96_c0s0",
-        "JA4SSH.2": "c76s76_c108s92_c0s0",
-        "JA4SSH.3": "c76s76_c106s94_c0s0",
-        "JA4SSH.4": "c76s76_c111s89_c0s0",
-        "JA4SSH.5": "c76s76_c66s65_c0s0"
+        "JA4SSH.1": "c64s64_c104s96_c19s82",
+        "JA4SSH.2": "c76s76_c108s92_c0s105",
+        "JA4SSH.3": "c76s76_c106s94_c0s107",
+        "JA4SSH.4": "c76s76_c111s89_c0s102",
+        "JA4SSH.5": "c76s76_c66s65_c9s51"
     },
     {
         "stream": 0,
@@ -58,7 +58,7 @@
             "ssh_protocol_server": "SSH-2.0-OpenSSH_7.4",
             "encryption_algorithm": "chacha20-poly1305@openssh.com"
         },
-        "JA4SSH.1": "c64s64_c107s93_c0s0",
-        "JA4SSH.2": "c64s64_c0s0_c0s0"
+        "JA4SSH.1": "c64s64_c107s93_c74s10",
+        "JA4SSH.2": "c64s64_c0s0_c0s1"
     }
 ]

--- a/python/test/testdata/ssh-scp-1050.pcap.json
+++ b/python/test/testdata/ssh-scp-1050.pcap.json
@@ -16,9 +16,9 @@
             "ssh_protocol_server": "SSH-2.0-OpenSSH_7.4",
             "encryption_algorithm": "chacha20-poly1305@openssh.com"
         },
-        "JA4SSH.1": "c112s1460_c52s148_c0s0",
-        "JA4SSH.2": "c112s1460_c13s187_c0s0",
-        "JA4SSH.3": "c112s1460_c0s200_c0s0",
-        "JA4SSH.4": "c112s1460_c0s200_c0s0"
+        "JA4SSH.1": "c112s1460_c52s148_c41s4",
+        "JA4SSH.2": "c112s1460_c13s187_c35s0",
+        "JA4SSH.3": "c112s1460_c0s200_c36s0",
+        "JA4SSH.4": "c112s1460_c0s200_c23s0"
     }
 ]

--- a/python/test/testdata/ssh2.pcapng.json
+++ b/python/test/testdata/ssh2.pcapng.json
@@ -148,8 +148,8 @@
             "ssh_protocol_server": "SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.1",
             "encryption_algorithm": "chacha20-poly1305@openssh.com"
         },
-        "JA4SSH.1": "c36s36_c76s124_c0s0",
-        "JA4SSH.2": "c36s36_c0s0_c0s0"
+        "JA4SSH.1": "c36s36_c76s124_c74s5",
+        "JA4SSH.2": "c36s36_c0s0_c2s0"
     },
     {
         "stream": 15,


### PR DESCRIPTION
 Improves JA4SSH fingerprint accuracy in the Python implementation by making SSH packet detection and stats handling more robust.

**Changes:**

* Detect SSH using `direction` and SSH-specific fields, not only `protos`
* Normalize parsing of `len`, `flags`, and ports
* Prefer explicit packet `direction` when available
* Correctly count bare ACKs (`0x0010`, zero payload) per client/server
* Use deterministic mode calculation for payload sizes

Python test fixtures are updated to reflect the corrected behavior.