### PR TITLE
Fix: Update ja4t logic to output padded zeroes for missing options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ wireshark/build-scripts/wireshark-*
 .vscode/
 __pycache__/
 .pytest_cache/
+.btest.failed.dat

--- a/zeek/ja4l/main.zeek
+++ b/zeek/ja4l/main.zeek
@@ -7,7 +7,7 @@
 # NOTE: JA4L can not work when traffic is out of order
 # Supress negative duration errors in local.zeek by setting
 # redef FINGERPRINT::JA4L::suppress_neg_ja4l_errors = T;
-# NOTE: Zeek JA4L does not attempt to handle duplicate packets.  
+# NOTE: Zeek JA4L does not attempt to handle duplicate packets.
 
 module FINGERPRINT::JA4L;
 

--- a/zeek/ja4t/main.zeek
+++ b/zeek/ja4t/main.zeek
@@ -195,21 +195,37 @@ event connection_state_remove(c: connection) {
         if(c$fp$ja4t$syn_window_size > 0) {
             c$conn$ja4t =  fmt("%d", c$fp$ja4t$syn_window_size);
             c$conn$ja4t += FINGERPRINT::delimiter;
-            c$conn$ja4t += FINGERPRINT::vector_of_count_to_str(c$fp$ja4t$syn_opts$option_kinds, "%d", "-");
+            if(|c$fp$ja4t$syn_opts$option_kinds| > 0) {
+                c$conn$ja4t += FINGERPRINT::vector_of_count_to_str(c$fp$ja4t$syn_opts$option_kinds, "%d", "-");
+            } else {
+                c$conn$ja4t += "00";
+            }
             c$conn$ja4t += FINGERPRINT::delimiter;
-            c$conn$ja4t += fmt("%d", c$fp$ja4t$syn_opts$max_segment_size);
+            c$conn$ja4t += fmt("%02d", c$fp$ja4t$syn_opts$max_segment_size);
             c$conn$ja4t += FINGERPRINT::delimiter;
-            c$conn$ja4t += fmt("%d", c$fp$ja4t$syn_opts$window_scale);
+            if(c$fp$ja4t$syn_opts$window_scale == 0) {
+                c$conn$ja4t += "00";
+            } else {
+                c$conn$ja4t += fmt("%d", c$fp$ja4t$syn_opts$window_scale);
+            }
         }
         @if(FINGERPRINT::JA4TS_enabled) 
         if(c$fp$ja4t$synack_window_size > 0) {
             c$conn$ja4ts =  fmt("%d", c$fp$ja4t$synack_window_size);
             c$conn$ja4ts += FINGERPRINT::delimiter;
-            c$conn$ja4ts += FINGERPRINT::vector_of_count_to_str(c$fp$ja4t$synack_opts$option_kinds, "%d", "-");
+            if(|c$fp$ja4t$synack_opts$option_kinds| > 0) {
+                c$conn$ja4ts += FINGERPRINT::vector_of_count_to_str(c$fp$ja4t$synack_opts$option_kinds, "%d", "-");
+            } else {
+                c$conn$ja4ts += "00";
+            }
             c$conn$ja4ts += FINGERPRINT::delimiter;
-            c$conn$ja4ts += fmt("%d", c$fp$ja4t$synack_opts$max_segment_size);
+            c$conn$ja4ts += fmt("%02d", c$fp$ja4t$synack_opts$max_segment_size);
             c$conn$ja4ts += FINGERPRINT::delimiter;
-            c$conn$ja4ts += fmt("%d", c$fp$ja4t$synack_opts$window_scale);
+            if(c$fp$ja4t$synack_opts$window_scale == 0) {
+                c$conn$ja4ts += "00";
+            } else {
+                c$conn$ja4ts += fmt("%d", c$fp$ja4t$synack_opts$window_scale);
+            }
             if(|c$fp$ja4t$synack_delays| > 0) {
                 c$conn$ja4ts += FINGERPRINT::delimiter;
                 c$conn$ja4ts += FINGERPRINT::vector_of_count_to_str(c$fp$ja4t$synack_delays, "%d", "-");

--- a/zeek/tests/Traces/Scripts.ja4-conn/conn.log
+++ b/zeek/tests/Traces/Scripts.ja4-conn/conn.log
@@ -6,4 +6,4 @@
 #path	conn
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	proto	service	duration	orig_bytes	resp_bytes	conn_state	local_orig	local_resp	missed_bytes	history	orig_pkts	orig_ip_bytes	resp_pkts	resp_ip_bytes	tunnel_parents	ip_proto	ja4l	ja4ls	ja4l_delta	ja4ls_delta	ja4t	ja4ts
 #types	time	string	addr	port	addr	port	enum	string	interval	count	count	string	bool	bool	count	string	count	count	count	count	set[string]	count	string	string	string	string	string	string
-1593980608.621087	C73Zcd4XqUIenT3Fef	2001:4998:ef83:14:8000::100d	64034	2606:4700::6811:d209	443	tcp	ssl	0.075341	237	2810	S1	F	F	0	ShADad	4	501	5	3122	-	6	35_64	18862_59_14792	(empty)	0.8	65535__0_0	65535__0_0
+1593980608.621087	C73Zcd4XqUIenT3Fef	2001:4998:ef83:14:8000::100d	64034	2606:4700::6811:d209	443	tcp	ssl	0.075341	237	2810	S1	F	F	0	ShADad	4	501	5	3122	-	6	35_64	18862_59_14792	(empty)	0.8	65535_00_00_00	65535_00_00_00


### PR DESCRIPTION
* fix: update ja4t logic to output padded zeroes for missing options

Updates `ja4t` and `ja4ts` format logic in Zeek to match the spec:
- Missing TCP options output as `00` instead of empty.
- Missing or zero-value MSS output as `00` instead of `0`.
- Missing or zero-value Window Scale output as `00` instead of `0`.

Updates corresponding btest baselines.

chore: remove .btest.failed.dat and add to .gitignore