### PR TITLE
Fix JA4+ fields not showing in Wireshark custom columns

### DIFF
--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -347,8 +347,11 @@ display_hashes_from_packet_table(proto_tree *tree, tvbuff_t *tvb, int frame_numb
     pkt_info_t *pi = packet_table_lookup(frame_number);
     if ((pi->complete) && (pi->insert_at)) {
         proto_tree *tree_location = locate_tree(tree, pi->insert_at);
-        if (tree_location == NULL)
-            return 0;
+        if (tree_location == NULL) {
+            // In non-visible trees the host protocol subtree may be absent/faked.
+            // Fall back to root so cached JA4 fields can still be replayed.
+            tree_location = tree;
+        }
 
         proto_tree *sub_tree = NULL;
         proto_tree *child = tree_location->first_child;
@@ -366,7 +369,9 @@ display_hashes_from_packet_table(proto_tree *tree, tvbuff_t *tvb, int frame_numb
             sub_tree = proto_item_add_subtree(ja4_ti, ett_ja4);
         }
 
-        if (sub_tree == NULL || sub_tree->finfo == NULL || sub_tree->finfo->tree_type == -1) {
+        // The JA4 wrapper may be faked in non-visible trees, but referenced
+        // leaf fields below it are still available for columns/field extraction.
+        if (sub_tree == NULL) {
             return 0;
         }
 

--- a/wireshark/test/test_tshark_output.py
+++ b/wireshark/test/test_tshark_output.py
@@ -54,3 +54,55 @@ def test_tshark_output_matches_expected(pcap_file):
     expected_lines = get_expected_output(pcap_file)
 
     assert actual_lines == expected_lines, f"Mismatch for {pcap_file.name}"
+
+
+# Regression for FoxIO #269 / Wireshark #20600:
+# JA4+ leaf fields must be available to custom columns and -T fields
+# even when the ja4 protocol itself is not referenced.
+COLUMN_CASES = [
+    # (pcap, ja4 field, expected value on the first matching frame)
+    ("tls-alpn-h2.pcap",     "ja4.ja4s", "t1204h2_cca9_1428ce7b4018"),
+    ("tls-alpn-h2.pcap",     "ja4.ja4t", "65535_2-1-3-1-1-8-4-0-0_1346_6"),
+    ("CVE-2018-6794.pcap",   "ja4.ja4t", "8192_2-1-3-1-1-4_1460_8"),
+    ("http1-with-cookies.pcapng", "ja4.ja4h",
+     "ge11cr04da00_8ddaef5d77af_280f366eaa04_c2fb0fe53442"),
+]
+
+
+def _first_nonempty(lines):
+    for line in lines:
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+@pytest.mark.parametrize("pcap_name,field,expected", COLUMN_CASES)
+def test_ja4_custom_column_is_populated(pcap_name, field, expected):
+    """JA4+ custom columns must work without -Y ja4."""
+    pcap_file = PCAP_DIR / pcap_name
+    col_fmt = f'gui.column.format:"No.","%m","JA4","%Cus:{field}:0:R"'
+    result = subprocess.run(
+        ["tshark", "-r", str(pcap_file), "-o", col_fmt],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    assert result.returncode == 0, f"tshark failed: {result.stderr}"
+    assert expected in result.stdout, (
+        f"{field} missing from custom column for {pcap_name}.\n"
+        f"Output:\n{result.stdout}"
+    )
+
+
+@pytest.mark.parametrize("pcap_name,field,expected", COLUMN_CASES)
+def test_ja4_fields_extraction_without_protocol_filter(pcap_name, field, expected):
+    """-T fields must extract JA4+ leaf fields without -Y ja4."""
+    pcap_file = PCAP_DIR / pcap_name
+    result = subprocess.run(
+        ["tshark", "-r", str(pcap_file), "-T", "fields", "-e", field],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    assert result.returncode == 0, f"tshark failed: {result.stderr}"
+    assert _first_nonempty(result.stdout.splitlines()) == expected, (
+        f"{field} extraction wrong for {pcap_name}.\n"
+        f"Output:\n{result.stdout}"
+    )


### PR DESCRIPTION
Fixes #269

## Summary

This PR fixes JA4+ fields not appearing in Wireshark custom columns, `tshark -T fields`, and display filters.

The fingerprints were already computed correctly and shown in the Packet Details pane, but the same fields could be empty when accessed through non-visible packet trees used by columns and field extraction.

## What was wrong

The JA4+ plugin is a post-dissector. It computes fingerprints, caches them, and re-adds them to the packet tree on later dissection passes.

When replaying cached values, the plugin wraps them in a `ja4` subtree. In Wireshark’s visible packet tree, used by the Packet Details pane, that wrapper is a normal real node. But for custom columns, `-T fields`, and display filters, Wireshark uses a stripped-down non-visible tree where unreferenced protocol nodes can be represented as fake placeholders.

The old code treated a fake `ja4` wrapper as a hard failure, so it returned before adding the actual JA4+ leaf fields, leaving custom columns and field extraction empty.

## Fix

The replay path now keeps going when the `ja4` wrapper is fake. The referenced JA4+ leaf fields, such as `ja4.ja4s`, are still materialized by Wireshark and can be used by custom columns, `-T fields`, and display filters.

The change also falls back to the root tree if the expected host protocol subtree cannot be found in a non-visible tree.

## Tests

Added regression coverage for the broken paths:

* JA4+ custom columns without `-Y ja4`
* `tshark -T fields -e ja4.<field>` without `-Y ja4`

<img width="1193" height="1010" alt="image" src="https://github.com/user-attachments/assets/539a66ab-d571-4018-aa2e-15544e91cf78" />
