### PR TITLE
Wireshark: fix fatal warnings for in-tree build

### DIFF
--- a/wireshark/source/packet-ja4.c
+++ b/wireshark/source/packet-ja4.c
@@ -15,13 +15,10 @@
 
 #include <math.h>
 #include <wsutil/to_str.h>
+#include <wsutil/array.h>
 
 #define FIELD_VALUE_IS_PTR \
     ((WIRESHARK_VERSION_MAJOR > 4) || (WIRESHARK_VERSION_MAJOR == 4 && WIRESHARK_VERSION_MINOR > 1))
-
-#ifndef array_length
-#define array_length(x) (sizeof(x) / sizeof(x)[0])
-#endif
 
 #include <epan/epan_dissect.h>
 #include <epan/ftypes/ftypes.h>
@@ -1057,7 +1054,7 @@ static int dissect_ja4(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void
                 }
                 // BUG-FIX: Ja4x should use Hex codes instead of ascii
                 const uint8_t *bytes = field_bytes(get_value_ptr(field));
-                for (int j = 0; j < field->length; j++) {
+                for (unsigned j = 0; j < field->length; j++) {
                     wmem_strbuf_append_printf(current_cert->oids[oid_type], "%02x", bytes[j]);
                 }
             }
@@ -1073,7 +1070,7 @@ static int dissect_ja4(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void
                 }
                 // BUG-FIX: Ja4x should use Hex codes instead of ascii
                 const uint8_t *bytes = field_bytes(get_value_ptr(field));
-                for (int j = 0; j < field->length; j++) {
+                for (unsigned j = 0; j < field->length; j++) {
                     wmem_strbuf_append_printf(current_cert->oids[oid_type], "%02x", bytes[j]);
                 }
             }


### PR DESCRIPTION
Fix sources of warnings in `packet-ja4.c` which cause in-tree build to fail, due to upstream Wireshark's use of `-Werror`. (As tested on Windows build using Visual Studio 2022.)

Remove custom `array_length()` macro and use `<wsutil/array.h>` instead, to avoid warnings about macro redefinition.
It's been around long enough now that this plugin can now safely depend on it.

Change loop indexes from `int` to `unsigned` to prevent warnings about signed/unsigned mismatches in comparisons.