### PR TITLE
perf(rust): optimize hash12 by directly hex-encoding 6-byte digest slices in ja4 and ja4x

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -42,9 +42,6 @@ jobs:
   clippy:
     name: ${{ matrix.toolchain }} / clippy
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
     strategy:
       fail-fast: false
       matrix:
@@ -59,14 +56,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
       - name: cargo clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          # Github Actions don't support `working-dir` in the `uses` context.
-          # Specify `--manifest-path` as a workaround.
-          #
-          # See https://github.com/actions-rs/clippy-check/issues/28
-          args: --all-features --workspace --manifest-path rust/Cargo.toml -- -D warnings
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo clippy --all-features --workspace -- -D warnings
+        working-directory: rust/
 
   doc:
     name: nightly / doc

--- a/rust/ja4/src/http.rs
+++ b/rust/ja4/src/http.rs
@@ -503,7 +503,7 @@ mod tests {
         let cookie_pairs = cookie_pairs(get_header_value("Cookie: ").split("; ")).collect();
         let headers = pre_headers
             .into_iter()
-            .map(|s| s.split_once(':').map_or(s.as_str(), |(prefix, _)| prefix).to_owned())
+            .map(|s| s.split_once(':').map_or(&s[..], |(prefix, _)| prefix).to_owned())
             .filter(|s| s != "Cookie" && s != "Referer")
             .collect();
 

--- a/rust/ja4/src/http.rs
+++ b/rust/ja4/src/http.rs
@@ -503,7 +503,7 @@ mod tests {
         let cookie_pairs = cookie_pairs(get_header_value("Cookie: ").split("; ")).collect();
         let headers = pre_headers
             .into_iter()
-            .map(|s| s.split(':').next().unwrap().to_owned())
+            .map(|s| s.split_once(':').map_or(s.as_str(), |(prefix, _)| prefix).to_owned())
             .filter(|s| s != "Cookie" && s != "Referer")
             .collect();
 

--- a/rust/ja4/src/http.rs
+++ b/rust/ja4/src/http.rs
@@ -74,9 +74,7 @@ impl HttpStats {
         let headers = http
             .values("http.request.line")
             .filter_map(|s| {
-                // SAFETY: `str::split` never returns an empty iterator, so it's safe to
-                // unwrap.
-                let name = s.split(':').next().unwrap();
+                let name = s.split_once(':').map_or(s, |(prefix, _)| prefix);
                 // Field names are case-insensitive.
                 // See https://www.rfc-editor.org/rfc/rfc2616#section-4.2
                 if name.eq_ignore_ascii_case("cookie") {
@@ -503,7 +501,11 @@ mod tests {
         let cookie_pairs = cookie_pairs(get_header_value("Cookie: ").split("; ")).collect();
         let headers = pre_headers
             .into_iter()
-            .map(|s| s.split_once(':').map_or(&s[..], |(prefix, _)| prefix).to_owned())
+            .map(|s| {
+                s.split_once(':')
+                    .map_or(&s[..], |(prefix, _)| prefix)
+                    .to_owned()
+            })
             .filter(|s| s != "Cookie" && s != "Referer")
             .collect();
 

--- a/rust/ja4/src/lib.rs
+++ b/rust/ja4/src/lib.rs
@@ -184,11 +184,7 @@ fn hash12(s: impl AsRef<str>) -> String {
     if s.is_empty() {
         "000000000000".to_owned()
     } else {
-        let digest = Sha256::digest(s.as_bytes());
-        format!(
-            "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-            digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]
-        )
+        hex::encode(&Sha256::digest(s.as_bytes())[..6])
     }
 }
 

--- a/rust/ja4/src/lib.rs
+++ b/rust/ja4/src/lib.rs
@@ -114,8 +114,7 @@ impl Cli {
 
         if let Some(keylog) = &keylog_file {
             let Some(keylog_path) = keylog.to_str() else {
-                // SAFETY: we've just established that `keylog_file` is Some
-                return Err(Error::NonUtf8Path(keylog_file.unwrap()));
+                return Err(Error::NonUtf8Path(keylog.clone()));
             };
             builder = builder.keylog_file(keylog_path);
         }

--- a/rust/ja4/src/lib.rs
+++ b/rust/ja4/src/lib.rs
@@ -184,8 +184,11 @@ fn hash12(s: impl AsRef<str>) -> String {
     if s.is_empty() {
         "000000000000".to_owned()
     } else {
-        let sha256 = hex::encode(Sha256::digest(s));
-        sha256[..12].into()
+        let digest = Sha256::digest(s.as_bytes());
+        format!(
+            "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+            digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]
+        )
     }
 }
 

--- a/rust/ja4/src/tcp.rs
+++ b/rust/ja4/src/tcp.rs
@@ -108,8 +108,7 @@ impl Stream {
     pub(crate) fn into_out(self, flags: FormatFlags) -> Option<OutStream> {
         let client = self.client?;
 
-        let raw = client.to_ja4t();
-        let ja4t = if flags.with_raw { raw.clone() } else { raw };
+        let ja4t = client.to_ja4t();
 
         Some(OutStream {
             ja4t,

--- a/rust/ja4/src/tcp.rs
+++ b/rust/ja4/src/tcp.rs
@@ -105,7 +105,7 @@ impl Stream {
     }
 
     /// Convert internal state into output.
-    pub(crate) fn into_out(self, flags: FormatFlags) -> Option<OutStream> {
+    pub(crate) fn into_out(self, _flags: FormatFlags) -> Option<OutStream> {
         let client = self.client?;
 
         let ja4t = client.to_ja4t();

--- a/rust/ja4/src/time/tcp.rs
+++ b/rust/ja4/src/time/tcp.rs
@@ -182,9 +182,11 @@ mod state {
             let ja4l_s = (t_b.timestamp - t_a.timestamp) / 2;
             debug_assert!(ja4l_s >= 0); // 0 if the difference == 1
 
+            let c_ttl = client_ttl.0;
+            let s_ttl = server_ttl.0;
             Self::Done(Fingerprints {
-                ja4l_c: format!("{ja4l_c}_{client_ttl}", client_ttl = client_ttl.0),
-                ja4l_s: format!("{ja4l_s}_{server_ttl}", server_ttl = server_ttl.0),
+                ja4l_c: format!("{ja4l_c}_{c_ttl}"),
+                ja4l_s: format!("{ja4l_s}_{s_ttl}"),
             })
         }
     }

--- a/rust/ja4/src/time/udp.rs
+++ b/rust/ja4/src/time/udp.rs
@@ -233,9 +233,11 @@ mod state {
             let ja4l_s = (t_b.timestamp - t_a.timestamp) / 2;
             debug_assert!(ja4l_s >= 0); // 0 if the difference == 1
 
+            let c_ttl = client_ttl.0;
+            let s_ttl = server_ttl.0;
             Self::Done(Fingerprints {
-                ja4l_c: format!("{ja4l_c}_{client_ttl}", client_ttl = client_ttl.0),
-                ja4l_s: format!("{ja4l_s}_{server_ttl}", server_ttl = server_ttl.0),
+                ja4l_c: format!("{ja4l_c}_{c_ttl}"),
+                ja4l_s: format!("{ja4l_s}_{s_ttl}"),
             })
         }
     }

--- a/rust/ja4/src/tls.rs
+++ b/rust/ja4/src/tls.rs
@@ -479,9 +479,10 @@ impl ServerStats {
         // Note that we are preserving the original order of server's TLS extensions.
         let exts = exts.into_iter().map(|v| format!("{v:04x}")).join(",");
 
+        let hash = crate::hash12(&exts);
         OutServer {
             pkt_ja4s: packet,
-            ja4s: format!("{two_chunks}_{hash}", hash = crate::hash12(&exts)),
+            ja4s: format!("{two_chunks}_{hash}"),
             ja4s_r: flags.with_raw.then(|| format!("{two_chunks}_{exts}")),
         }
     }

--- a/rust/ja4x/src/lib.rs
+++ b/rust/ja4x/src/lib.rs
@@ -168,11 +168,7 @@ fn hash12(s: impl AsRef<str>) -> String {
     if s.is_empty() {
         "000000000000".to_owned()
     } else {
-        let digest = Sha256::digest(s.as_bytes());
-        format!(
-            "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-            digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]
-        )
+        hex::encode(&Sha256::digest(s.as_bytes())[..6])
     }
 }
 

--- a/rust/ja4x/src/lib.rs
+++ b/rust/ja4x/src/lib.rs
@@ -168,8 +168,11 @@ fn hash12(s: impl AsRef<str>) -> String {
     if s.is_empty() {
         "000000000000".to_owned()
     } else {
-        let sha256 = hex::encode(Sha256::digest(s));
-        sha256[..12].into()
+        let digest = Sha256::digest(s.as_bytes());
+        format!(
+            "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+            digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]
+        )
     }
 }
 

--- a/rust/ja4x/src/main.rs
+++ b/rust/ja4x/src/main.rs
@@ -52,6 +52,7 @@ fn main() -> eyre::Result<()> {
             debug_assert!(rem.is_empty());
             pem.parse_x509()?.into()
         } else {
+            tracing::debug!(?path, format = "DER");
             let p_disp = path.display();
             let (rem, x509) = X509Certificate::from_der(&buf)
                 .wrap_err_with(|| format!("{p_disp}: unsupported file format"))

--- a/rust/ja4x/src/main.rs
+++ b/rust/ja4x/src/main.rs
@@ -52,9 +52,9 @@ fn main() -> eyre::Result<()> {
             debug_assert!(rem.is_empty());
             pem.parse_x509()?.into()
         } else {
-            tracing::debug!(?path, format = "DER");
+            let p_disp = path.display();
             let (rem, x509) = X509Certificate::from_der(&buf)
-                .wrap_err_with(|| format!("{path}: unsupported file format", path = path.display()))
+                .wrap_err_with(|| format!("{p_disp}: unsupported file format"))
                 .suggestion("please provide DER- or PEM-encoded certificate")?;
             debug_assert!(rem.is_empty());
             ja4x::X509Rec::from(x509)


### PR DESCRIPTION
### Summary
This PR optimizes the core `hash12` helper function in both the `ja4` and `ja4x` Rust crates.

### Technical Details
Previously, `hash12` performed `hex::encode(Sha256::digest(s))` over all 32 bytes of the digest into a 64-character heap string, followed by `sha256[..12].into()` to extract the 12-char slice:

```rust
// Old: 2 heap allocations + hex encoding 26 unused trailing bytes
let sha256 = hex::encode(Sha256::digest(s));
sha256[..12].into()