### PR TITLE
fix(python): JA4L second-rollover, JA4H referer flag, hops TTL

### DIFF
--- a/python/common.py
+++ b/python/common.py
@@ -6,7 +6,7 @@
 #
 
 from hashlib import sha256
-from datetime import datetime
+from datetime import datetime, timedelta
 
 conn_cache = {}
 quic_cache = {}
@@ -179,7 +179,9 @@ def parse_timestamp(timestamp):
 def epoch_diff(t1, t2):
     dt1 = parse_timestamp(t1)
     dt2 = parse_timestamp(t2)
-    return int((dt2-dt1).microseconds/2)
+    # timedelta.microseconds only holds the sub-second component, so any
+    # difference of a second or more was silently truncated before.
+    return (dt2 - dt1) // timedelta(microseconds=2)
 
 
 # Scan for tls

--- a/python/ja4.py
+++ b/python/ja4.py
@@ -139,7 +139,7 @@ output_types = [ 'ja4x', 'ja4h' , 'ja4', 'ja4s', 'ja4ssh', 'ja4l']
 ########### JA4 / JA4S FUNCTIONS #####################
 def hops(x):
     x = int(x)
-    initial_ttl = 54
+    initial_ttl = 64
     if x > 64 and x <= 128:
         initial_ttl = 128
     if x > 128:

--- a/python/ja4h.py
+++ b/python/ja4h.py
@@ -23,7 +23,7 @@ def to_ja4h(x, debug_stream=-1):
         x['headers'] = [h.strip() for h in x['headers'].split('\n') if h.strip()]
     
     header_fields = [y.lower().split(':')[0] for y in x['headers']]
-    referer = 'r' if 'referer' in str(header_fields) else 'n'
+    referer = 'r' if 'referer' in header_fields else 'n'
 
     method = http_method(x['method'])
     

--- a/python/test/test_ja4_unit.py
+++ b/python/test/test_ja4_unit.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from common import epoch_diff  # noqa: E402
+from ja4 import hops  # noqa: E402
+from ja4h import to_ja4h  # noqa: E402
+
+
+def test_epoch_diff_spans_seconds():
+    t1 = "2020-01-17T20:43:36.000000Z"
+    t2 = "2020-01-17T20:43:37.250000Z"
+    # 1.25 s of round-trip time -> 625000 microseconds one-way
+    assert epoch_diff(t1, t2) == 625000
+
+
+def test_epoch_diff_sub_second_precision():
+    t1 = "2020-01-17T20:43:36.000000Z"
+    t2 = "2020-01-17T20:43:36.000500Z"
+    assert epoch_diff(t1, t2) == 250
+
+
+def test_hops_uses_the_regular_initial_ttl_ladder():
+    assert hops(64) == 0
+    assert hops(60) == 4
+    assert hops(128) == 0
+    assert hops(120) == 8
+    assert hops(200) == 55
+
+
+def _ja4h_referer_flag(headers):
+    x = {
+        "hl": "http",
+        "stream": "9",
+        "method": "GET",
+        "headers": ["GET / HTTP/1.1"] + headers,
+    }
+    result = to_ja4h(x, debug_stream=-1)
+    # JA4H layout: method(2) version(2) cookie(1) referer(1) ...
+    return result["JA4H"][5]
+
+
+def test_ja4h_referer_flag_requires_exact_header():
+    assert _ja4h_referer_flag(["Referer: https://example.com/"]) == "r"
+
+
+def test_ja4h_referer_flag_ignores_lookalike_headers():
+    assert _ja4h_referer_flag(["X-Referer: https://example.com/"]) == "n"


### PR DESCRIPTION
Three fixes in the Python fingerprinters, plus unit tests.

**1. epoch_diff truncated any gap of a second or more** (common.py)

`(dt2 - dt1).microseconds` returns the sub-second component of the timedelta, not its total length. Every JA4L packet gap of ≥ 1s was silently cut to its remainder: a 1.25s handshake gap produced `125` instead of `625000` microseconds one-way. Slow links, Tor connections or lossy retries can easily cross the one-second mark, and the resulting JA4L was quietly wrong rather than failing loudly. The fix uses the full timedelta; sub-second results are bit-identical, so all golden JA4L values are unchanged.

**2. JA4H counted X-Referer as Referer** (ja4h.py)

`'referer' in str(header_fields)` is a substring check over the list repr, so any header whose name contains "referer" set the referer flag. A request carrying only `X-Referer` was fingerprinted as if it had a real `Referer`. Now an exact list membership check.

**3. hops() started the TTL ladder at 54** (ja4.py)

The lowest initial TTL should be 64 (the 64/128/255 ladder); the typo produced negative hop counts for observed TTLs between 55 and 64.

**Tests**: python/test/test_ja4_unit.py covers the second-rollover case of epoch_diff, the TTL ladder and the referer flag (including the lookalike-header case). No golden outputs change: sub-second JA4L results are identical.

(The JA4X issuer/subject extraction originally in this PR has been split out for separate work after review feedback.)