### PR TITLE
fix(python): handle ALPN edge cases like the rust implementation

### DIFF
--- a/python/ja4.py
+++ b/python/ja4.py
@@ -146,6 +146,21 @@ def hops(x):
         initial_ttl = 255
     return (initial_ttl - x)
 
+def first_last_alpn(alpn):
+    # Keep the first and last character of the ALPN value, which is all the
+    # fingerprint needs. Matches the rust implementation: a non-ascii
+    # character is replaced with '9', a single character is followed by '0',
+    # and an empty value (or a missing ALPN extension) becomes '00'.
+    if isinstance(alpn, list):
+        alpn = alpn[0] if alpn else ''
+    if not alpn:
+        return '00'
+    first = alpn[0] if ord(alpn[0]) < 128 else '9'
+    if len(alpn) == 1:
+        return f"{first}0"
+    last = alpn[-1] if ord(alpn[-1]) < 128 else '9'
+    return f"{first}{last}"
+
 def calculate_ja4_latency(x, ptype, STREAM):
     try:
         cache = get_cache(x)
@@ -195,16 +210,7 @@ def to_ja4s(x, debug_stream):
         x['version'] = get_supported_version(x['supported_versions'])
     version = TLS_MAPPER[x['version']] if x['version'] in TLS_MAPPER else '00'
   
-    alpn = '00' 
-    if 'alpn_list' in x:
-        if isinstance(x['alpn_list'], list):
-            alpn = x['alpn_list'][0]
-        else:
-            alpn = x['alpn_list']
-    if len(alpn) > 2:
-        alpn = f"{alpn[0]}{alpn[-1]}"
-    if ord(alpn[0]) > 127:
-        alpn = '99'
+    alpn = first_last_alpn(x['alpn_list'] if 'alpn_list' in x else '')
 
     x['JA4S'] = f"{ptype}{version}{ext_len}{alpn}_{x['ciphers']}_{extensions}"
     x['JA4S_r'] = f"{ptype}{version}{ext_len}{alpn}_{x['ciphers']}_{','.join(x['extensions'])}"
@@ -266,18 +272,7 @@ def to_ja4(x, debug_stream):
         x['version'] = get_supported_version(x['supported_versions'])
     version = TLS_MAPPER[x['version']] if x['version'] in TLS_MAPPER else '00'
 
-    alpn = '00' 
-    if 'alpn_list' in x:
-        if isinstance(x['alpn_list'], list):
-            alpn = x['alpn_list'][0]
-        else:
-            alpn = x['alpn_list']
-
-    if len(alpn) > 2:
-        alpn = f"{alpn[0]}{alpn[-1]}"
-
-    if ord(alpn[0]) > 127:
-        alpn = '99'
+    alpn = first_last_alpn(x['alpn_list'] if 'alpn_list' in x else '')
 
     entry = get_cache(x)[x['stream']]
     if not entry.get('count'):

--- a/python/test/test_ja4_unit.py
+++ b/python/test/test_ja4_unit.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from common import epoch_diff  # noqa: E402
-from ja4 import hops  # noqa: E402
+from common import cache_update, epoch_diff  # noqa: E402
+from ja4 import first_last_alpn, hops, to_ja4s  # noqa: E402
 from ja4h import to_ja4h  # noqa: E402
 
 
@@ -47,3 +47,33 @@ def test_ja4h_referer_flag_requires_exact_header():
 
 def test_ja4h_referer_flag_ignores_lookalike_headers():
     assert _ja4h_referer_flag(["X-Referer: https://example.com/"]) == "n"
+
+
+def test_first_last_alpn_matches_the_rust_implementation():
+    assert first_last_alpn("h2") == "h2"
+    assert first_last_alpn("http/1.1") == "h1"
+    assert first_last_alpn("x") == "x0"
+    # a non-ascii character becomes '9', per character
+    assert first_last_alpn("\u00e9x") == "9x"
+    assert first_last_alpn("x\u00e9") == "x9"
+    # an empty ALPN value behaves like a missing one
+    assert first_last_alpn("") == "00"
+    assert first_last_alpn(None) == "00"
+    # several offered protocols: the first one counts
+    assert first_last_alpn(["h2", "h3"]) == "h2"
+
+
+def test_to_ja4s_survives_an_empty_alpn_value():
+    x = {
+        "hl": "tls",
+        "stream": 7,
+        "quic": False,
+        "version": "0x0303",
+        "ciphers": ["0x1301"],
+        "extensions": ["0x0016"],
+        "alpn_list": "",
+    }
+    cache_update(x, "stream", 7, -1)
+    to_ja4s(x, debug_stream=-1)
+    # JA4S layout: transport(1) version(2) extension count(2) alpn(2)
+    assert x["JA4S"][5:7] == "00"


### PR DESCRIPTION
An empty ALPN value — a zero-length protocol name inside the ALPN extension — made `ord(alpn[0])` raise `IndexError` in `to_ja4()` and `to_ja4s()`:

```python
  File "ja4.py", line 206, in to_ja4s
    if ord(alpn[0]) > 127:
IndexError: string index out of range
```

`tshark -T ek` reports `tls.handshake.extensions_alpn_str` as an empty string when the ALPN extension carries a zero-length name, so one ServerHello like that aborts the whole run in `to_ja4s()` (it isn't guarded in `main()`), losing every fingerprint from the capture. In `to_ja4()` the exception is swallowed and streams with an empty client-side ALPN silently disappear from the output.

Two smaller divergences from the rust implementation came from the same block: a single-character ALPN rendered as one character instead of two (`x` instead of `x0`), and non-ascii was only checked at position 0 (`éx` became `99` where rust yields `9x`).

The handling now mirrors `first_last()` in `rust/ja4/src/tls.rs`: first and last character of the value, non-ascii replaced with `9` per character, a single character padded with `0`, and an empty value treated like a missing extension (`00`). `to_ja4()` and `to_ja4s()` share one helper now.
